### PR TITLE
Add ticket reply and note functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,32 @@ freshdesk ticket search "login issue"
 freshdesk ticket search "user@example.com"
 ```
 
+#### Reply to Tickets
+
+```bash
+# Reply with message directly
+freshdesk ticket reply 123 --message "Thank you for your inquiry. We're looking into this."
+
+# Reply from file
+freshdesk ticket reply 123 --file response.txt
+
+# Interactive reply (will prompt for message)
+freshdesk ticket reply 123
+```
+
+#### Add Internal Notes
+
+```bash
+# Add internal note directly
+freshdesk ticket note 123 --message "Customer has premium support, prioritize this."
+
+# Add note from file
+freshdesk ticket note 123 --file internal-notes.txt
+
+# Interactive note (will prompt)
+freshdesk ticket note 123
+```
+
 ### Attachment Operations
 
 #### List Attachments
@@ -195,6 +221,8 @@ freshdesk ticket list --format json | jq '.[] | {id, subject, status}'
 | `ticket create` | Create a new ticket |
 | `ticket update <id>` | Update ticket status/priority |
 | `ticket search <query>` | Search tickets |
+| `ticket reply <id>` | Reply to a ticket |
+| `ticket note <id>` | Add internal note to a ticket |
 
 ### Attachment Commands
 

--- a/src/FreshdeskCLI/Program.cs
+++ b/src/FreshdeskCLI/Program.cs
@@ -77,6 +77,8 @@ static void ShowHelp()
     Console.WriteLine("  ticket create     Create a new ticket");
     Console.WriteLine("  ticket update     Update ticket status/priority");
     Console.WriteLine("  ticket search     Search tickets");
+    Console.WriteLine("  ticket reply      Reply to a ticket");
+    Console.WriteLine("  ticket note       Add internal note to a ticket");
     Console.WriteLine("  attachment list    List attachments for a ticket");
     Console.WriteLine("  attachment download Download an attachment");
     Console.WriteLine("  attachment upload  Upload an attachment to a ticket");
@@ -238,6 +240,8 @@ static async Task<int> HandleTicketCommand(string[] args, bool isReadOnly = fals
         Console.WriteLine("  create    Create a new ticket");
         Console.WriteLine("  update    Update ticket status/priority");
         Console.WriteLine("  search    Search tickets");
+        Console.WriteLine("  reply     Reply to a ticket");
+        Console.WriteLine("  note      Add internal note to a ticket");
         return 1;
     }
 
@@ -259,6 +263,8 @@ static async Task<int> HandleTicketCommand(string[] args, bool isReadOnly = fals
         "create" => isReadOnly ? ShowReadOnlyError("ticket create") : await HandleTicketCreate(args[1..], client),
         "update" => isReadOnly ? ShowReadOnlyError("ticket update") : await HandleTicketUpdate(args[1..], client),
         "search" => await HandleTicketSearch(args[1..], client),
+        "reply" => isReadOnly ? ShowReadOnlyError("ticket reply") : await HandleTicketReply(args[1..], client),
+        "note" => isReadOnly ? ShowReadOnlyError("ticket note") : await HandleTicketNote(args[1..], client),
         _ => ShowUnknownCommand($"ticket {args[0]}")
     };
 }
@@ -556,6 +562,160 @@ static async Task<int> HandleTicketSearch(string[] args, FreshdeskCLI.Services.F
 
     Console.WriteLine($"\nFound {filtered.Length} matching tickets");
     return 0;
+}
+
+static async Task<int> HandleTicketReply(string[] args, FreshdeskCLI.Services.FreshdeskApiClient client)
+{
+    if (args.Length < 1 || !long.TryParse(args[0], out var ticketId))
+    {
+        Console.WriteLine("Usage: freshdesk ticket reply <ticket-id> [options]");
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --message, -m <text>   Reply message (or will prompt)");
+        Console.WriteLine("  --file, -f <path>      Read message from file");
+        return 1;
+    }
+
+    string? message = null;
+    string? filePath = null;
+
+    for (int i = 1; i < args.Length; i++)
+    {
+        switch (args[i])
+        {
+            case "--message":
+            case "-m":
+                if (i + 1 < args.Length)
+                    message = args[++i];
+                break;
+            case "--file":
+            case "-f":
+                if (i + 1 < args.Length)
+                    filePath = args[++i];
+                break;
+        }
+    }
+
+    // Get message from file if specified
+    if (!string.IsNullOrEmpty(filePath))
+    {
+        if (!File.Exists(filePath))
+        {
+            Console.WriteLine($"File not found: {filePath}");
+            return 1;
+        }
+        message = await File.ReadAllTextAsync(filePath);
+    }
+
+    // If no message provided, prompt for it
+    if (string.IsNullOrEmpty(message))
+    {
+        Console.WriteLine("Enter your reply (press Ctrl+D or type 'EOF' on a new line when done):");
+        var lines = new List<string>();
+        string? line;
+        while ((line = Console.ReadLine()) != null && line != "EOF")
+        {
+            lines.Add(line);
+        }
+        message = string.Join("\n", lines);
+    }
+
+    if (string.IsNullOrEmpty(message))
+    {
+        Console.WriteLine("No message provided.");
+        return 1;
+    }
+
+    try
+    {
+        Console.WriteLine($"Sending reply to ticket #{ticketId}...");
+        var conversation = await client.ReplyToTicketAsync(ticketId, message, isPrivate: false);
+        Console.WriteLine($"✓ Reply sent successfully!");
+        Console.WriteLine($"  Conversation ID: {conversation.Id}");
+        Console.WriteLine($"  Created: {conversation.CreatedAt:yyyy-MM-dd HH:mm:ss}");
+        return 0;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Failed to send reply: {ex.Message}");
+        return 1;
+    }
+}
+
+static async Task<int> HandleTicketNote(string[] args, FreshdeskCLI.Services.FreshdeskApiClient client)
+{
+    if (args.Length < 1 || !long.TryParse(args[0], out var ticketId))
+    {
+        Console.WriteLine("Usage: freshdesk ticket note <ticket-id> [options]");
+        Console.WriteLine("Options:");
+        Console.WriteLine("  --message, -m <text>   Note message (or will prompt)");
+        Console.WriteLine("  --file, -f <path>      Read message from file");
+        return 1;
+    }
+
+    string? message = null;
+    string? filePath = null;
+
+    for (int i = 1; i < args.Length; i++)
+    {
+        switch (args[i])
+        {
+            case "--message":
+            case "-m":
+                if (i + 1 < args.Length)
+                    message = args[++i];
+                break;
+            case "--file":
+            case "-f":
+                if (i + 1 < args.Length)
+                    filePath = args[++i];
+                break;
+        }
+    }
+
+    // Get message from file if specified
+    if (!string.IsNullOrEmpty(filePath))
+    {
+        if (!File.Exists(filePath))
+        {
+            Console.WriteLine($"File not found: {filePath}");
+            return 1;
+        }
+        message = await File.ReadAllTextAsync(filePath);
+    }
+
+    // If no message provided, prompt for it
+    if (string.IsNullOrEmpty(message))
+    {
+        Console.WriteLine("Enter your internal note (press Ctrl+D or type 'EOF' on a new line when done):");
+        var lines = new List<string>();
+        string? line;
+        while ((line = Console.ReadLine()) != null && line != "EOF")
+        {
+            lines.Add(line);
+        }
+        message = string.Join("\n", lines);
+    }
+
+    if (string.IsNullOrEmpty(message))
+    {
+        Console.WriteLine("No message provided.");
+        return 1;
+    }
+
+    try
+    {
+        Console.WriteLine($"Adding internal note to ticket #{ticketId}...");
+        var conversation = await client.ReplyToTicketAsync(ticketId, message, isPrivate: true);
+        Console.WriteLine($"✓ Internal note added successfully!");
+        Console.WriteLine($"  Note ID: {conversation.Id}");
+        Console.WriteLine($"  Created: {conversation.CreatedAt:yyyy-MM-dd HH:mm:ss}");
+        return 0;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Failed to add note: {ex.Message}");
+        return 1;
+    }
 }
 
 static void TestAotCompatibility()


### PR DESCRIPTION
## Summary
Completes the conversation management feature by adding reply and note capabilities.

## New Commands

### Reply to Tickets
```bash
# Direct reply
freshdesk ticket reply 123 --message "Thanks for reaching out"

# Reply from file  
freshdesk ticket reply 123 --file response.txt

# Interactive (prompts for input)
freshdesk ticket reply 123
```

### Add Internal Notes
```bash
# Direct note
freshdesk ticket note 123 --message "Priority customer"

# Note from file
freshdesk ticket note 123 --file notes.txt  

# Interactive
freshdesk ticket note 123
```

## Features
- ✅ Direct message via `--message` flag
- ✅ Read from file via `--file` flag
- ✅ Interactive mode with multi-line input (type EOF to finish)
- ✅ Read-only mode protection
- ✅ Clear success/error feedback

## Safety
- Both commands respect read-only mode
- File validation before reading
- Proper error handling for API failures

This completes the full conversation management feature set alongside the viewing capabilities from the previous PR.