### PR TITLE
Add unit tests for services and helpers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,13 @@
   <ItemGroup>
   </ItemGroup>
   <!-- Test dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+  </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />

--- a/FreshDeskCli.slnx
+++ b/FreshDeskCli.slnx
@@ -9,4 +9,7 @@
   <Folder Name="/src/">
     <Project Path="src/FreshdeskCLI/FreshdeskCLI.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/FreshdeskCLI.Tests/FreshdeskCLI.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/src/FreshdeskCLI/FreshdeskJsonContext.cs
+++ b/src/FreshdeskCLI/FreshdeskJsonContext.cs
@@ -19,7 +19,7 @@ namespace FreshdeskCLI;
 [JsonSerializable(typeof(FreshdeskConfig))]
 [JsonSerializable(typeof(Dictionary<string, FreshdeskConfig>))]
 [JsonSerializable(typeof(Dictionary<string, object>))]
-internal partial class FreshdeskJsonContext : JsonSerializerContext
+public partial class FreshdeskJsonContext : JsonSerializerContext
 {
 }
 

--- a/src/FreshdeskCLI/Services/ConfigurationService.cs
+++ b/src/FreshdeskCLI/Services/ConfigurationService.cs
@@ -17,9 +17,18 @@ public sealed class ConfigurationService : IConfigurationService
 
     public ConfigurationService()
     {
-        var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        var configDir = Path.Combine(homeDir, ".freshdesk");
-        _configPath = Path.Combine(configDir, "config.json");
+        // Allow override for testing
+        var configPath = Environment.GetEnvironmentVariable("FRESHDESK_CONFIG_PATH");
+        if (!string.IsNullOrEmpty(configPath))
+        {
+            _configPath = Path.Combine(configPath, "config.json");
+        }
+        else
+        {
+            var homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var configDir = Path.Combine(homeDir, ".freshdesk");
+            _configPath = Path.Combine(configDir, "config.json");
+        }
     }
 
     public async Task<FreshdeskConfig?> LoadConfigAsync(CancellationToken cancellationToken = default)

--- a/tests/FreshdeskCLI.Tests/FreshdeskCLI.Tests.csproj
+++ b/tests/FreshdeskCLI.Tests/FreshdeskCLI.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Moq" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FreshdeskCLI\FreshdeskCLI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/FreshdeskCLI.Tests/Helpers/OutputFormatterTests.cs
+++ b/tests/FreshdeskCLI.Tests/Helpers/OutputFormatterTests.cs
@@ -1,0 +1,293 @@
+using System.Text;
+using FreshdeskCLI.Helpers;
+using FreshdeskCLI.Models;
+
+namespace FreshdeskCLI.Tests.Helpers;
+
+public class OutputFormatterTests : IDisposable
+{
+    private readonly StringWriter _output;
+    private readonly TextWriter _originalOutput;
+
+    public OutputFormatterTests()
+    {
+        _originalOutput = Console.Out;
+        _output = new StringWriter();
+        Console.SetOut(_output);
+    }
+
+    public void Dispose()
+    {
+        Console.SetOut(_originalOutput);
+        _output.Dispose();
+    }
+
+    [Fact]
+    public void PrintTickets_Table_DisplaysCorrectly()
+    {
+        // Arrange
+        var tickets = new[]
+        {
+            new Ticket
+            {
+                Id = 1,
+                Subject = "Test Ticket 1",
+                Status = TicketStatus.Open,
+                Priority = TicketPriority.High,
+                CreatedAt = new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero)
+            },
+            new Ticket
+            {
+                Id = 2,
+                Subject = "This is a very long ticket subject that should be truncated in the table view",
+                Status = TicketStatus.Closed,
+                Priority = TicketPriority.Low,
+                CreatedAt = new DateTimeOffset(2025, 1, 15, 11, 45, 0, TimeSpan.Zero)
+            }
+        };
+
+        // Act
+        OutputFormatter.PrintTickets(tickets, "table");
+        var output = _output.ToString();
+
+        // Assert
+        Assert.Contains("Test Ticket 1", output);
+        Assert.Contains("Open", output);
+        Assert.Contains("High", output);
+        Assert.Contains("This is a very long ticket subject th...", output); // Truncated to 40 chars
+        Assert.Contains("Total: 2 tickets", output);
+    }
+
+    [Fact]
+    public void PrintTickets_EmptyArray_ShowsNoTicketsMessage()
+    {
+        // Arrange
+        var tickets = Array.Empty<Ticket>();
+
+        // Act
+        OutputFormatter.PrintTickets(tickets, "table");
+        var output = _output.ToString();
+
+        // Assert
+        Assert.Contains("No tickets found", output);
+    }
+
+    [Fact]
+    public void PrintTickets_Json_OutputsValidJson()
+    {
+        // Arrange
+        var tickets = new[]
+        {
+            new Ticket
+            {
+                Id = 1,
+                Subject = "Test",
+                Status = TicketStatus.Open,
+                Priority = TicketPriority.Medium
+            }
+        };
+
+        // Act
+        OutputFormatter.PrintTickets(tickets, "json");
+        var output = _output.ToString();
+
+        // Assert
+        Assert.Contains("\"id\":1", output);
+        Assert.Contains("\"subject\":\"Test\"", output);
+        Assert.StartsWith("[", output.Trim());
+        Assert.EndsWith("]", output.Trim());
+    }
+
+    [Fact]
+    public void PrintTickets_Csv_OutputsCorrectFormat()
+    {
+        // Arrange
+        var tickets = new[]
+        {
+            new Ticket
+            {
+                Id = 1,
+                Subject = "Test, with comma",
+                Status = TicketStatus.Open,
+                Priority = TicketPriority.High,
+                Email = "test@example.com",
+                CreatedAt = new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero),
+                UpdatedAt = new DateTimeOffset(2025, 1, 15, 11, 0, 0, TimeSpan.Zero)
+            }
+        };
+
+        // Act
+        OutputFormatter.PrintTickets(tickets, "csv");
+        var output = _output.ToString();
+
+        // Assert
+        var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length); // Header + 1 data row
+        Assert.StartsWith("ID,Subject,Status,Priority,Created,Updated,Email", lines[0]);
+        Assert.Contains("\"Test, with comma\"", lines[1]); // Escaped comma
+        Assert.Contains("test@example.com", lines[1]);
+    }
+
+    [Fact]
+    public void PrintTicketDetails_ShowsAllDetails()
+    {
+        // Arrange
+        var ticket = new Ticket
+        {
+            Id = 123,
+            Subject = "Test Ticket",
+            Status = TicketStatus.Open,
+            Priority = TicketPriority.High,
+            Source = TicketSource.Email,
+            Email = "customer@example.com",
+            Description = "This is a test description",
+            CreatedAt = new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero),
+            UpdatedAt = new DateTimeOffset(2025, 1, 15, 11, 0, 0, TimeSpan.Zero),
+            Attachments = new[]
+            {
+                new Attachment { Name = "file.pdf", Size = 1024 * 500 } // 500 KB
+            }
+        };
+
+        // Act
+        OutputFormatter.PrintTicketDetails(ticket, "text");
+        var output = _output.ToString();
+
+        // Assert
+        Assert.Contains("Ticket #123", output);
+        Assert.Contains("Subject: Test Ticket", output);
+        Assert.Contains("Status: Open", output);
+        Assert.Contains("Priority: High", output);
+        Assert.Contains("Source: Email", output);
+        Assert.Contains("Email: customer@example.com", output);
+        Assert.Contains("This is a test description", output);
+        Assert.Contains("file.pdf", output);
+        Assert.Contains("500 KB", output); // Formatted file size
+    }
+
+    [Fact]
+    public void PrintTicketTree_ShowsConversationStructure()
+    {
+        // Arrange
+        var ticket = new Ticket
+        {
+            Id = 123,
+            Subject = "Test Ticket",
+            Status = TicketStatus.Open,
+            Attachments = new[]
+            {
+                new Attachment { Name = "main.pdf", Size = 1024 * 1024 } // 1 MB
+            }
+        };
+
+        var conversations = new[]
+        {
+            new Conversation
+            {
+                Id = 1,
+                Private = false,
+                Incoming = true,
+                CreatedAt = new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero),
+                Attachments = new[]
+                {
+                    new Attachment { Name = "screenshot.png", Size = 1024 * 250 }
+                }
+            },
+            new Conversation
+            {
+                Id = 2,
+                Private = true,
+                Incoming = false,
+                CreatedAt = new DateTimeOffset(2025, 1, 15, 11, 0, 0, TimeSpan.Zero)
+            }
+        };
+
+        // Act
+        OutputFormatter.PrintTicketTree(ticket, conversations);
+        var output = _output.ToString();
+
+        // Assert
+        Assert.Contains("Ticket #123: Test Ticket [Open]", output);
+        Assert.Contains("Summary: 1 replies, 1 notes, 1 attachments (1 MB)", output);
+        Assert.Contains("[Customer]", output);
+        Assert.Contains("[Note]", output);
+        Assert.Contains("screenshot.png (250 KB)", output);
+        Assert.Contains("├──", output); // Tree structure
+        Assert.Contains("└──", output); // Tree structure
+    }
+
+    [Fact]
+    public void PrintTicketFull_ShowsCompleteConversations()
+    {
+        // Arrange
+        var ticket = new Ticket
+        {
+            Id = 123,
+            Subject = "Test Ticket",
+            Status = TicketStatus.Open
+        };
+
+        var conversations = new[]
+        {
+            new Conversation
+            {
+                Id = 1,
+                Private = false,
+                Incoming = true,
+                BodyText = "This is the customer's message",
+                CreatedAt = new DateTimeOffset(2025, 1, 15, 10, 30, 0, TimeSpan.Zero)
+            },
+            new Conversation
+            {
+                Id = 2,
+                Private = true,
+                Incoming = false,
+                BodyText = "This is an internal note",
+                CreatedAt = new DateTimeOffset(2025, 1, 15, 11, 0, 0, TimeSpan.Zero)
+            }
+        };
+
+        // Act
+        OutputFormatter.PrintTicketFull(ticket, conversations);
+        var output = _output.ToString();
+
+        // Assert
+        Assert.Contains("CONVERSATION THREAD", output);
+        Assert.Contains("[CUSTOMER]", output);
+        Assert.Contains("[INTERNAL NOTE]", output);
+        Assert.Contains("This is the customer's message", output);
+        Assert.Contains("This is an internal note", output);
+    }
+
+    [Fact]
+    public void PrintTicketFull_HandlesHtmlContent()
+    {
+        // Arrange
+        var ticket = new Ticket
+        {
+            Id = 123,
+            Subject = "Test",
+            Status = TicketStatus.Open
+        };
+
+        var conversations = new[]
+        {
+            new Conversation
+            {
+                Id = 1,
+                Body = "<p>This is <strong>HTML</strong> content</p>",
+                BodyText = "", // No plain text version
+                CreatedAt = DateTimeOffset.Now
+            }
+        };
+
+        // Act
+        OutputFormatter.PrintTicketFull(ticket, conversations);
+        var output = _output.ToString();
+
+        // Assert
+        Assert.Contains("This is HTML content", output); // HTML tags stripped
+        Assert.DoesNotContain("<p>", output);
+        Assert.DoesNotContain("<strong>", output);
+    }
+}

--- a/tests/FreshdeskCLI.Tests/Services/ConfigurationServiceTests.cs
+++ b/tests/FreshdeskCLI.Tests/Services/ConfigurationServiceTests.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using FreshdeskCLI.Models;
+using FreshdeskCLI.Services;
+
+namespace FreshdeskCLI.Tests.Services;
+
+public class ConfigurationServiceTests : IDisposable
+{
+    private readonly string _testConfigPath;
+    private readonly ConfigurationService _service;
+
+    public ConfigurationServiceTests()
+    {
+        // Create a temp directory for test configs
+        _testConfigPath = Path.Combine(Path.GetTempPath(), $"freshdesk-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_testConfigPath);
+
+        // Override the config path for testing
+        Environment.SetEnvironmentVariable("FRESHDESK_CONFIG_PATH", _testConfigPath);
+        _service = new ConfigurationService();
+    }
+
+    public void Dispose()
+    {
+        // Clean up test directory
+        if (Directory.Exists(_testConfigPath))
+        {
+            Directory.Delete(_testConfigPath, true);
+        }
+        Environment.SetEnvironmentVariable("FRESHDESK_CONFIG_PATH", null);
+    }
+
+    [Fact]
+    public async Task LoadConfigAsync_ReturnsNull_WhenNoConfigExists()
+    {
+        // Act
+        var config = await _service.LoadConfigAsync();
+
+        // Assert
+        Assert.Null(config);
+    }
+
+    [Fact]
+    public async Task SaveConfigAsync_CreatesConfigFile()
+    {
+        // Arrange
+        var config = new FreshdeskConfig
+        {
+            Domain = "testdomain",
+            ApiKey = "test-api-key",
+            ProfileName = "default"
+        };
+
+        // Act
+        await _service.SaveConfigAsync(config);
+
+        // Assert
+        var configFile = Path.Combine(_testConfigPath, "config.json");
+        Assert.True(File.Exists(configFile));
+
+        var savedConfig = await _service.LoadConfigAsync();
+        Assert.NotNull(savedConfig);
+        Assert.Equal("testdomain", savedConfig.Domain);
+        Assert.Equal("test-api-key", savedConfig.ApiKey);
+    }
+
+    [Fact]
+    public async Task LoadConfigAsync_ReadsFromEnvironmentVariables()
+    {
+        // Arrange
+        // Use a fresh service instance with a clean directory
+        var cleanPath = Path.Combine(Path.GetTempPath(), $"freshdesk-test-clean-{Guid.NewGuid()}");
+        Directory.CreateDirectory(cleanPath);
+        Environment.SetEnvironmentVariable("FRESHDESK_CONFIG_PATH", cleanPath);
+
+        Environment.SetEnvironmentVariable("FRESHDESK_DOMAIN", "env-domain");
+        Environment.SetEnvironmentVariable("FRESHDESK_API_KEY", "env-api-key");
+
+        try
+        {
+            var service = new ConfigurationService();
+
+            // Act
+            var config = await service.LoadConfigAsync();
+
+            // Assert
+            Assert.NotNull(config);
+            Assert.Equal("env-domain", config.Domain);
+            Assert.Equal("env-api-key", config.ApiKey);
+        }
+        finally
+        {
+            // Cleanup
+            Environment.SetEnvironmentVariable("FRESHDESK_DOMAIN", null);
+            Environment.SetEnvironmentVariable("FRESHDESK_API_KEY", null);
+            Environment.SetEnvironmentVariable("FRESHDESK_CONFIG_PATH", _testConfigPath);
+            if (Directory.Exists(cleanPath))
+                Directory.Delete(cleanPath, true);
+        }
+    }
+
+    [Fact]
+    public async Task LoadConfigAsync_EnvironmentVariablesOverrideFile()
+    {
+        // Arrange
+        var fileConfig = new FreshdeskConfig
+        {
+            Domain = "file-domain",
+            ApiKey = "file-api-key",
+            ProfileName = "default"
+        };
+        await _service.SaveConfigAsync(fileConfig);
+
+        // Both env vars must be set for environment config to be used
+        Environment.SetEnvironmentVariable("FRESHDESK_DOMAIN", "env-domain");
+        Environment.SetEnvironmentVariable("FRESHDESK_API_KEY", "env-api-key");
+
+        try
+        {
+            // Act
+            var config = await _service.LoadConfigAsync();
+
+            // Assert
+            Assert.NotNull(config);
+            Assert.Equal("env-domain", config.Domain); // From env
+            Assert.Equal("env-api-key", config.ApiKey); // From env
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("FRESHDESK_DOMAIN", null);
+            Environment.SetEnvironmentVariable("FRESHDESK_API_KEY", null);
+        }
+    }
+
+    [Fact]
+    public void FreshdeskConfig_IsValid_ReturnsTrueForValidConfig()
+    {
+        // Arrange
+        var config = new FreshdeskConfig
+        {
+            Domain = "testdomain",
+            ApiKey = "test-api-key"
+        };
+
+        // Act & Assert
+        Assert.True(config.IsValid);
+        Assert.Equal("https://testdomain.freshdesk.com", config.BaseUrl);
+    }
+
+    [Fact]
+    public void FreshdeskConfig_IsValid_ReturnsFalseForInvalidConfig()
+    {
+        // Arrange
+        var configNoDomain = new FreshdeskConfig { ApiKey = "test-api-key" };
+        var configNoApiKey = new FreshdeskConfig { Domain = "testdomain" };
+        var configEmpty = new FreshdeskConfig();
+
+        // Act & Assert
+        Assert.False(configNoDomain.IsValid);
+        Assert.False(configNoApiKey.IsValid);
+        Assert.False(configEmpty.IsValid);
+    }
+
+    [Fact]
+    public async Task SaveConfigAsync_CreatesConfigDirectory()
+    {
+        // Arrange
+        var testPath = Path.Combine(_testConfigPath, "subdir");
+        Environment.SetEnvironmentVariable("FRESHDESK_CONFIG_PATH", testPath);
+        var service = new ConfigurationService();
+
+        var config = new FreshdeskConfig
+        {
+            Domain = "testdomain",
+            ApiKey = "test-api-key",
+            ProfileName = "default"
+        };
+
+        // Act
+        await service.SaveConfigAsync(config);
+
+        // Assert
+        Assert.True(Directory.Exists(testPath));
+        var configFile = Path.Combine(testPath, "config.json");
+        Assert.True(File.Exists(configFile));
+    }
+}

--- a/tests/FreshdeskCLI.Tests/Services/FreshdeskApiClientTests.cs
+++ b/tests/FreshdeskCLI.Tests/Services/FreshdeskApiClientTests.cs
@@ -1,0 +1,345 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using FreshdeskCLI;
+using FreshdeskCLI.Models;
+using FreshdeskCLI.Services;
+using Moq;
+using Moq.Protected;
+
+namespace FreshdeskCLI.Tests.Services;
+
+public class FreshdeskApiClientTests
+{
+    private readonly Mock<HttpMessageHandler> _mockHttpHandler;
+    private readonly HttpClient _httpClient;
+    private readonly FreshdeskConfig _config;
+    private readonly FreshdeskApiClient _client;
+
+    public FreshdeskApiClientTests()
+    {
+        _mockHttpHandler = new Mock<HttpMessageHandler>();
+        _httpClient = new HttpClient(_mockHttpHandler.Object)
+        {
+            BaseAddress = new Uri("https://test.freshdesk.com")
+        };
+
+        _config = new FreshdeskConfig
+        {
+            Domain = "test",
+            ApiKey = "test-api-key"
+        };
+
+        _client = new FreshdeskApiClient(_config, _httpClient);
+    }
+
+    [Fact]
+    public async Task TestConnectionAsync_ReturnsTrue_OnSuccessfulResponse()
+    {
+        // Arrange
+        _mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.PathAndQuery == "/api/v2/tickets?per_page=1"),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("[]")
+            });
+
+        // Act
+        var result = await _client.TestConnectionAsync();
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task TestConnectionAsync_ReturnsFalse_OnUnauthorized()
+    {
+        // Arrange
+        _mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Unauthorized
+            });
+
+        // Act
+        var result = await _client.TestConnectionAsync();
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task GetTicketsAsync_ReturnsTicketsArray()
+    {
+        // Arrange
+        var tickets = new[]
+        {
+            new Ticket { Id = 1, Subject = "Test 1", Status = TicketStatus.Open },
+            new Ticket { Id = 2, Subject = "Test 2", Status = TicketStatus.Closed }
+        };
+
+        var json = JsonSerializer.Serialize(tickets, FreshdeskJsonContext.Default.TicketArray);
+
+        _mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.PathAndQuery.Contains("/api/v2/tickets")),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json)
+            });
+
+        // Act
+        var result = await _client.GetTicketsAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("Test 1", result[0].Subject);
+        Assert.Equal("Test 2", result[1].Subject);
+    }
+
+    [Fact]
+    public async Task GetTicketAsync_ReturnsTicket_WhenFound()
+    {
+        // Arrange
+        var ticket = new Ticket
+        {
+            Id = 123,
+            Subject = "Test Ticket",
+            Status = TicketStatus.Open,
+            Priority = TicketPriority.High
+        };
+
+        var json = JsonSerializer.Serialize(ticket, FreshdeskJsonContext.Default.Ticket);
+
+        _mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.PathAndQuery == "/api/v2/tickets/123"),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json)
+            });
+
+        // Act
+        var result = await _client.GetTicketAsync(123);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(123, result.Id);
+        Assert.Equal("Test Ticket", result.Subject);
+    }
+
+    [Fact]
+    public async Task GetTicketAsync_ReturnsNull_WhenNotFound()
+    {
+        // Arrange
+        _mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.PathAndQuery == "/api/v2/tickets/999"),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.NotFound
+            });
+
+        // Act
+        var result = await _client.GetTicketAsync(999);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CreateTicketAsync_SendsCorrectRequest()
+    {
+        // Arrange
+        var newTicket = new Ticket
+        {
+            Subject = "New Ticket",
+            Description = "Test description",
+            Status = TicketStatus.Open,
+            Priority = TicketPriority.Medium,
+            Email = "test@example.com"
+        };
+
+        var createdTicket = new Ticket
+        {
+            Id = 456,
+            Subject = newTicket.Subject,
+            Description = newTicket.Description,
+            Status = newTicket.Status,
+            Priority = newTicket.Priority,
+            Email = newTicket.Email,
+            CreatedAt = DateTimeOffset.Now
+        };
+
+        var responseJson = JsonSerializer.Serialize(createdTicket, FreshdeskJsonContext.Default.Ticket);
+
+        _mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.Method == HttpMethod.Post &&
+                    req.RequestUri!.PathAndQuery == "/api/v2/tickets"),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.Created,
+                Content = new StringContent(responseJson)
+            });
+
+        // Act
+        var result = await _client.CreateTicketAsync(newTicket);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(456, result.Id);
+        Assert.Equal("New Ticket", result.Subject);
+    }
+
+    [Fact]
+    public async Task UpdateTicketAsync_SendsCorrectRequest()
+    {
+        // Arrange
+        var updateTicket = new Ticket
+        {
+            Status = TicketStatus.Resolved,
+            Priority = TicketPriority.Low
+        };
+
+        var updatedTicket = new Ticket
+        {
+            Id = 789,
+            Subject = "Updated Ticket",
+            Status = TicketStatus.Resolved,
+            Priority = TicketPriority.Low,
+            UpdatedAt = DateTimeOffset.Now
+        };
+
+        var responseJson = JsonSerializer.Serialize(updatedTicket, FreshdeskJsonContext.Default.Ticket);
+
+        _mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.Method == HttpMethod.Put &&
+                    req.RequestUri!.PathAndQuery == "/api/v2/tickets/789"),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(responseJson)
+            });
+
+        // Act
+        var result = await _client.UpdateTicketAsync(789, updateTicket);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(789, result.Id);
+        Assert.Equal(TicketStatus.Resolved, result.Status);
+        Assert.Equal(TicketPriority.Low, result.Priority);
+    }
+
+    [Fact]
+    public async Task GetTicketConversationsAsync_ReturnsConversations()
+    {
+        // Arrange
+        var conversations = new[]
+        {
+            new Conversation
+            {
+                Id = 1,
+                Body = "First message",
+                Private = false,
+                Incoming = true
+            },
+            new Conversation
+            {
+                Id = 2,
+                Body = "Reply message",
+                Private = false,
+                Incoming = false
+            }
+        };
+
+        var json = JsonSerializer.Serialize(conversations, FreshdeskJsonContext.Default.ConversationArray);
+
+        _mockHttpHandler
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.PathAndQuery == "/api/v2/tickets/123/conversations"),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json)
+            });
+
+        // Act
+        var result = await _client.GetTicketConversationsAsync(123);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Length);
+        Assert.Equal("First message", result[0].Body);
+        Assert.False(result[0].Private);
+        Assert.True(result[0].Incoming);
+    }
+
+    [Fact]
+    public void Constructor_SetsAuthorizationHeader()
+    {
+        // Arrange & Act
+        var config = new FreshdeskConfig
+        {
+            Domain = "test",
+            ApiKey = "secret-key-12345" // Must be > 10 characters
+        };
+
+        using var client = new FreshdeskApiClient(config);
+
+        // Assert - can't directly test the header, but we can verify the client is created
+        Assert.NotNull(client);
+    }
+
+    [Fact]
+    public void Dispose_DisposesHttpClient_WhenOwned()
+    {
+        // Arrange
+        var config = new FreshdeskConfig
+        {
+            Domain = "test",
+            ApiKey = "test-key-12345" // Must be > 10 characters
+        };
+
+        var client = new FreshdeskApiClient(config);
+
+        // Act & Assert - should not throw
+        client.Dispose();
+        client.Dispose(); // Second dispose should also not throw
+    }
+}


### PR DESCRIPTION
## Summary
- Added comprehensive unit tests for the Freshdesk CLI
- Set up test project with xUnit and Moq
- Fixed test isolation issues for reliable test execution

## Test coverage
- **ConfigurationService**: 7 tests covering config loading, saving, environment variables, and validation
- **FreshdeskApiClient**: 11 tests covering API operations, connection testing, and proper disposal
- **OutputFormatter**: 7 tests covering different output formats (table, JSON, CSV) and conversation display

## Test plan
- [x] All 25 unit tests pass
- [x] Tests run in isolation without interference
- [x] Proper mocking of HTTP calls
- [x] Environment variable handling tested