### PR TITLE
Add progress indicators for long operations

### DIFF
--- a/src/FreshdeskCLI/Helpers/ProgressIndicator.cs
+++ b/src/FreshdeskCLI/Helpers/ProgressIndicator.cs
@@ -1,0 +1,156 @@
+using System.Diagnostics;
+
+namespace FreshdeskCLI.Helpers;
+
+public interface IProgressIndicator : IDisposable
+{
+    void Report(int current, int total, string? message = null);
+    void Report(double percentage, string? message = null);
+    void Complete(string? message = null);
+}
+
+public sealed class ConsoleProgressIndicator : IProgressIndicator
+{
+    private readonly string _title;
+    private readonly bool _showPercentage;
+    private readonly bool _showSpinner;
+    private readonly Stopwatch _stopwatch;
+    private readonly object _lock = new();
+    private int _lastLineLength;
+    private int _spinnerIndex;
+    private bool _isCompleted;
+
+    private static readonly string[] SpinnerFrames = { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
+
+    public ConsoleProgressIndicator(string title, bool showPercentage = true, bool showSpinner = true)
+    {
+        _title = title;
+        _showPercentage = showPercentage;
+        _showSpinner = showSpinner;
+        _stopwatch = Stopwatch.StartNew();
+
+        // Initial display
+        Console.Write($"{_title}... ");
+        if (_showSpinner)
+        {
+            Console.Write(SpinnerFrames[0]);
+        }
+    }
+
+    public void Report(int current, int total, string? message = null)
+    {
+        if (total <= 0) return;
+
+        var percentage = (double)current / total;
+        Report(percentage, message);
+    }
+
+    public void Report(double percentage, string? message = null)
+    {
+        lock (_lock)
+        {
+            if (_isCompleted) return;
+
+            // Clear the current line
+            Console.Write($"\r{new string(' ', _lastLineLength)}\r");
+
+            var output = _title;
+
+            if (_showSpinner)
+            {
+                _spinnerIndex = (_spinnerIndex + 1) % SpinnerFrames.Length;
+                output += $" {SpinnerFrames[_spinnerIndex]}";
+            }
+
+            if (_showPercentage)
+            {
+                var percent = Math.Min(100, Math.Max(0, percentage * 100));
+                output += $" [{percent:0}%]";
+
+                // Add progress bar
+                var barWidth = 20;
+                var completed = (int)(barWidth * percentage);
+                var bar = new string('█', completed) + new string('░', barWidth - completed);
+                output += $" {bar}";
+            }
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                output += $" - {message}";
+            }
+
+            // Add elapsed time
+            var elapsed = _stopwatch.Elapsed;
+            if (elapsed.TotalSeconds > 2)
+            {
+                output += $" ({FormatTime(elapsed)})";
+            }
+
+            Console.Write(output);
+            _lastLineLength = output.Length;
+        }
+    }
+
+    public void Complete(string? message = null)
+    {
+        lock (_lock)
+        {
+            if (_isCompleted) return;
+            _isCompleted = true;
+
+            _stopwatch.Stop();
+
+            // Clear the current line
+            Console.Write($"\r{new string(' ', _lastLineLength)}\r");
+
+            var output = $"✓ {_title}";
+            if (!string.IsNullOrEmpty(message))
+            {
+                output += $" - {message}";
+            }
+            output += $" ({FormatTime(_stopwatch.Elapsed)})";
+
+            Console.WriteLine(output);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (!_isCompleted)
+        {
+            Complete();
+        }
+    }
+
+    private static string FormatTime(TimeSpan timeSpan)
+    {
+        if (timeSpan.TotalHours >= 1)
+            return $"{timeSpan.Hours}h {timeSpan.Minutes}m {timeSpan.Seconds}s";
+        if (timeSpan.TotalMinutes >= 1)
+            return $"{timeSpan.Minutes}m {timeSpan.Seconds}s";
+        if (timeSpan.TotalSeconds >= 1)
+            return $"{timeSpan.Seconds}.{timeSpan.Milliseconds / 100}s";
+        return $"{timeSpan.Milliseconds}ms";
+    }
+}
+
+public sealed class SilentProgressIndicator : IProgressIndicator
+{
+    public void Report(int current, int total, string? message = null) { }
+    public void Report(double percentage, string? message = null) { }
+    public void Complete(string? message = null) { }
+    public void Dispose() { }
+}
+
+public static class ProgressIndicatorFactory
+{
+    public static IProgressIndicator Create(string title, bool enabled = true, bool showPercentage = true, bool showSpinner = true)
+    {
+        if (!enabled || Console.IsOutputRedirected)
+        {
+            return new SilentProgressIndicator();
+        }
+
+        return new ConsoleProgressIndicator(title, showPercentage, showSpinner);
+    }
+}

--- a/src/FreshdeskCLI/Program.cs
+++ b/src/FreshdeskCLI/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using FreshdeskCLI;
 using FreshdeskCLI.Models;
 using FreshdeskCLI.Helpers;
+using FreshdeskCLI.Services;
 
 // For now, use a simpler approach without System.CommandLine's complex features
 // System.CommandLine is AOT-compatible but the beta API is still evolving
@@ -840,9 +841,15 @@ static async Task<int> HandleAttachmentList(string[] args, FreshdeskCLI.Services
 
 static async Task<int> HandleAttachmentDownload(string[] args, FreshdeskCLI.Services.FreshdeskApiClient client)
 {
+    // Check if user wants to download all attachments
+    if (args.Length >= 2 && args[1].Equals("all", StringComparison.OrdinalIgnoreCase))
+    {
+        return await HandleBulkAttachmentDownload(args, client);
+    }
+
     if (args.Length < 2 || !long.TryParse(args[0], out var ticketId))
     {
-        Console.WriteLine("Usage: freshdesk attachment download <ticket-id> <attachment-id> [--output <path>]");
+        Console.WriteLine("Usage: freshdesk attachment download <ticket-id> <attachment-id|all> [--output <path>]");
         return 1;
     }
 
@@ -891,6 +898,73 @@ static async Task<int> HandleAttachmentDownload(string[] args, FreshdeskCLI.Serv
         Console.Error.WriteLine($"Failed to download attachment: {ex.Message}");
         return 1;
     }
+}
+
+static async Task<int> HandleBulkAttachmentDownload(string[] args, FreshdeskCLI.Services.FreshdeskApiClient client)
+{
+    if (args.Length < 1 || !long.TryParse(args[0], out var ticketId))
+    {
+        Console.WriteLine("Usage: freshdesk attachment download <ticket-id> all [--output <path>]");
+        return 1;
+    }
+
+    var ticket = await client.GetTicketAsync(ticketId);
+    if (ticket == null)
+    {
+        Console.WriteLine($"Ticket {ticketId} not found.");
+        return 1;
+    }
+
+    if (ticket.Attachments == null || ticket.Attachments.Length == 0)
+    {
+        Console.WriteLine($"No attachments found for ticket #{ticketId}");
+        return 0;
+    }
+
+    // Parse output path
+    var outputPath = Environment.CurrentDirectory;
+    var outputIndex = Array.IndexOf(args, "--output");
+    if (outputIndex >= 0 && outputIndex < args.Length - 1)
+    {
+        outputPath = args[outputIndex + 1];
+    }
+
+    // Create folder for ticket attachments
+    var ticketFolder = Path.Combine(outputPath, $"ticket_{ticketId}_attachments");
+    Directory.CreateDirectory(ticketFolder);
+
+    var bulkService = new BulkOperationService(client);
+    var result = await bulkService.DownloadAttachmentsAsync(ticket, ticketFolder, showProgress: true);
+
+    Console.WriteLine($"\nDownload Summary:");
+    Console.WriteLine($"  Successfully downloaded: {result.SuccessCount}/{result.TotalFiles} files");
+    Console.WriteLine($"  Total size: {FormatFileSize(result.TotalBytes)}");
+    Console.WriteLine($"  Location: {ticketFolder}");
+
+    if (result.ErrorCount > 0)
+    {
+        Console.WriteLine($"\nErrors occurred for {result.ErrorCount} files:");
+        foreach (var error in result.Errors)
+        {
+            Console.WriteLine($"  - {error.Error}");
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
+static string FormatFileSize(long bytes)
+{
+    string[] sizes = { "B", "KB", "MB", "GB", "TB" };
+    double len = bytes;
+    int order = 0;
+    while (len >= 1024 && order < sizes.Length - 1)
+    {
+        order++;
+        len = len / 1024;
+    }
+    return $"{len:0.##} {sizes[order]}";
 }
 
 static async Task<int> HandleAttachmentUpload(string[] args, FreshdeskCLI.Services.FreshdeskApiClient client)

--- a/src/FreshdeskCLI/Services/BulkOperationService.cs
+++ b/src/FreshdeskCLI/Services/BulkOperationService.cs
@@ -1,0 +1,237 @@
+using FreshdeskCLI.Helpers;
+using FreshdeskCLI.Models;
+
+namespace FreshdeskCLI.Services;
+
+public interface IBulkOperationService
+{
+    Task<BulkOperationResult<T>> ProcessBulkAsync<T>(
+        IEnumerable<long> ids,
+        Func<long, Task<T>> operation,
+        string operationName,
+        int maxConcurrency = 5,
+        bool showProgress = true,
+        CancellationToken cancellationToken = default);
+
+    Task<BulkDownloadResult> DownloadAttachmentsAsync(
+        Ticket ticket,
+        string downloadPath,
+        bool showProgress = true,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class BulkOperationService : IBulkOperationService
+{
+    private readonly IFreshdeskApiClient _apiClient;
+
+    public BulkOperationService(IFreshdeskApiClient apiClient)
+    {
+        _apiClient = apiClient;
+    }
+
+    public async Task<BulkOperationResult<T>> ProcessBulkAsync<T>(
+        IEnumerable<long> ids,
+        Func<long, Task<T>> operation,
+        string operationName,
+        int maxConcurrency = 5,
+        bool showProgress = true,
+        CancellationToken cancellationToken = default)
+    {
+        var idList = ids.ToList();
+        var results = new List<T>();
+        var errors = new List<BulkOperationError>();
+
+        using var progress = ProgressIndicatorFactory.Create(
+            $"Processing {operationName}",
+            enabled: showProgress);
+
+        var semaphore = new SemaphoreSlim(maxConcurrency, maxConcurrency);
+        var completed = 0;
+        var total = idList.Count;
+
+        var tasks = idList.Select(async id =>
+        {
+            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                var result = await operation(id);
+                lock (results)
+                {
+                    results.Add(result);
+                    completed++;
+                    progress.Report(completed, total, $"Processed {completed}/{total}");
+                }
+            }
+            catch (Exception ex)
+            {
+                lock (errors)
+                {
+                    errors.Add(new BulkOperationError
+                    {
+                        Id = id,
+                        Error = ex.Message
+                    });
+                    completed++;
+                    progress.Report(completed, total, $"Processed {completed}/{total} (with errors)");
+                }
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        await Task.WhenAll(tasks);
+
+        progress.Complete($"Completed {results.Count} successfully, {errors.Count} errors");
+
+        return new BulkOperationResult<T>
+        {
+            Successful = results,
+            Errors = errors,
+            TotalProcessed = idList.Count,
+            SuccessCount = results.Count,
+            ErrorCount = errors.Count
+        };
+    }
+
+    public async Task<BulkDownloadResult> DownloadAttachmentsAsync(
+        Ticket ticket,
+        string downloadPath,
+        bool showProgress = true,
+        CancellationToken cancellationToken = default)
+    {
+        if (ticket.Attachments == null || ticket.Attachments.Length == 0)
+        {
+            return new BulkDownloadResult
+            {
+                TotalFiles = 0,
+                SuccessCount = 0,
+                ErrorCount = 0,
+                TotalBytes = 0,
+                Files = Array.Empty<string>(),
+                Errors = Array.Empty<BulkOperationError>()
+            };
+        }
+
+        Directory.CreateDirectory(downloadPath);
+
+        var files = new List<string>();
+        var errors = new List<BulkOperationError>();
+        var totalBytes = 0L;
+
+        using var progress = ProgressIndicatorFactory.Create(
+            $"Downloading attachments for ticket #{ticket.Id}",
+            enabled: showProgress);
+
+        var completed = 0;
+        var total = ticket.Attachments.Length;
+
+        foreach (var attachment in ticket.Attachments)
+        {
+            try
+            {
+                progress.Report(completed, total, $"Downloading {attachment.Name}");
+
+                if (string.IsNullOrEmpty(attachment.AttachmentUrl))
+                {
+                    throw new InvalidOperationException($"No URL for attachment {attachment.Name}");
+                }
+
+                var content = await _apiClient.DownloadAttachmentAsync(attachment.AttachmentUrl, cancellationToken);
+
+                var safeFileName = GetSafeFileName(attachment.Name ?? $"attachment_{attachment.Id}");
+                var filePath = Path.Combine(downloadPath, safeFileName);
+
+                // Handle duplicate file names
+                var counter = 1;
+                while (File.Exists(filePath))
+                {
+                    var nameWithoutExt = Path.GetFileNameWithoutExtension(safeFileName);
+                    var ext = Path.GetExtension(safeFileName);
+                    filePath = Path.Combine(downloadPath, $"{nameWithoutExt}_{counter}{ext}");
+                    counter++;
+                }
+
+                await File.WriteAllBytesAsync(filePath, content, cancellationToken);
+
+                files.Add(filePath);
+                totalBytes += content.Length;
+                completed++;
+
+                progress.Report(completed, total, $"Downloaded {attachment.Name} ({FormatBytes(content.Length)})");
+            }
+            catch (Exception ex)
+            {
+                errors.Add(new BulkOperationError
+                {
+                    Id = attachment.Id,
+                    Error = $"Failed to download {attachment.Name}: {ex.Message}"
+                });
+                completed++;
+                progress.Report(completed, total, $"Failed: {attachment.Name}");
+            }
+        }
+
+        progress.Complete($"Downloaded {files.Count}/{total} files ({FormatBytes(totalBytes)})");
+
+        return new BulkDownloadResult
+        {
+            TotalFiles = total,
+            SuccessCount = files.Count,
+            ErrorCount = errors.Count,
+            TotalBytes = totalBytes,
+            Files = files.ToArray(),
+            Errors = errors.ToArray()
+        };
+    }
+
+    private static string GetSafeFileName(string fileName)
+    {
+        var invalid = Path.GetInvalidFileNameChars();
+        var safe = fileName;
+        foreach (var c in invalid)
+        {
+            safe = safe.Replace(c, '_');
+        }
+        return safe;
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] sizes = { "B", "KB", "MB", "GB", "TB" };
+        double len = bytes;
+        int order = 0;
+        while (len >= 1024 && order < sizes.Length - 1)
+        {
+            order++;
+            len = len / 1024;
+        }
+        return $"{len:0.##} {sizes[order]}";
+    }
+}
+
+public sealed class BulkOperationResult<T>
+{
+    public required List<T> Successful { get; init; }
+    public required List<BulkOperationError> Errors { get; init; }
+    public required int TotalProcessed { get; init; }
+    public required int SuccessCount { get; init; }
+    public required int ErrorCount { get; init; }
+}
+
+public sealed class BulkDownloadResult
+{
+    public required int TotalFiles { get; init; }
+    public required int SuccessCount { get; init; }
+    public required int ErrorCount { get; init; }
+    public required long TotalBytes { get; init; }
+    public required string[] Files { get; init; }
+    public required BulkOperationError[] Errors { get; init; }
+}
+
+public sealed class BulkOperationError
+{
+    public required long Id { get; init; }
+    public required string Error { get; init; }
+}

--- a/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
+++ b/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
@@ -14,7 +14,7 @@ public interface IFreshdeskApiClient
     Task<Ticket> UpdateTicketAsync(long ticketId, Ticket ticket, CancellationToken cancellationToken = default);
     Task<Conversation[]> GetTicketConversationsAsync(long ticketId, CancellationToken cancellationToken = default);
     Task<Conversation> ReplyToTicketAsync(long ticketId, string body, bool isPrivate = false, CancellationToken cancellationToken = default);
-    Task<Stream> DownloadAttachmentAsync(string attachmentUrl, CancellationToken cancellationToken = default);
+    Task<byte[]> DownloadAttachmentAsync(string attachmentUrl, CancellationToken cancellationToken = default);
     Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default);
 }
 
@@ -147,7 +147,7 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
         return JsonSerializer.Deserialize(responseJson, FreshdeskJsonContext.Default.Conversation)!;
     }
 
-    public async Task<Stream> DownloadAttachmentAsync(string attachmentUrl, CancellationToken cancellationToken = default)
+    public async Task<byte[]> DownloadAttachmentAsync(string attachmentUrl, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(attachmentUrl);
 
@@ -155,7 +155,7 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
         var response = await _httpClient.GetAsync(attachmentUrl, cancellationToken);
         response.EnsureSuccessStatusCode();
 
-        return await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await response.Content.ReadAsByteArrayAsync(cancellationToken);
     }
 
     public async Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Implemented visual progress indicators for time-consuming operations
- Added bulk download support with progress tracking
- Provides better user feedback during long-running tasks

## Features
- **ConsoleProgressIndicator**: Shows spinner, percentage, progress bar, and elapsed time
- **BulkOperationService**: Manages batch operations with concurrent execution and progress
- **Bulk attachment download**: Download all attachments from a ticket with `attachment download <id> all`
- **Smart progress display**: Automatically disabled when output is redirected

## Usage examples
```bash
# Download all attachments from a ticket with progress
freshdesk attachment download 123 all --output /downloads

# Progress shows:
# Downloading attachments for ticket #123 ⠸ [45%] ████████░░░░░░░░░░░░ - Downloading report.pdf (2.3 MB) (5.2s)
```

## Test plan
- [x] Progress indicators work correctly in terminal
- [x] Progress is suppressed when output is redirected  
- [x] Bulk downloads complete successfully
- [x] Error handling during bulk operations