### PR TITLE
Remove linux-arm64 from release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,6 @@ jobs:
           - os: ubuntu-latest
             runtime: linux-x64
             archive: tar.gz
-          - os: ubuntu-latest
-            runtime: linux-arm64
-            archive: tar.gz
           - os: windows-latest
             runtime: win-x64
             archive: zip


### PR DESCRIPTION
Fixes the release workflow by removing the problematic linux-arm64 target.

## Issue
Linux ARM64 AOT cross-compilation fails due to missing linker emulation for aarch64-linux-gnu on x64 GitHub runners:


## Solution  
Remove the linux-arm64 target from the release matrix. We still have good platform coverage with:
- linux-x64
- win-x64  
- osx-x64
- osx-arm64

## Future
We can add linux-arm64 back later using self-hosted ARM64 runners or when GitHub Actions provides proper cross-compilation support.