### PR TITLE
Fix installer bug and add quick install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ A fast, lightweight command-line interface for [Freshdesk](https://www.freshwork
 
 ## Installation
 
+### Quick Install (Recommended)
+
+**Linux/macOS:**
+```bash
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash
+```
+
+**Windows (PowerShell):**
+```powershell
+iwr -useb https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.ps1 | iex
+```
+
+**Install Beta Releases:**
+```bash
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash -s -- --beta
+```
+
 ### From Source
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -76,11 +76,9 @@ get_latest_version() {
     if [ "$include_prerelease" = true ]; then
         # Get all releases and find the latest (including pre-releases)
         api_url="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
-        info "Fetching latest release information (including pre-releases)..."
     else
         # Get only the latest stable release
         api_url="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest"
-        info "Fetching latest stable release information..."
     fi
     
     local response
@@ -236,6 +234,11 @@ main() {
     info "Detected platform: ${platform}"
     
     # Get latest version
+    if [ "$include_beta" = true ]; then
+        info "Fetching latest release information (including pre-releases)..."
+    else
+        info "Fetching latest stable release information..."
+    fi
     local version
     version=$(get_latest_version "$include_beta")
     info "Latest version: ${version}"


### PR DESCRIPTION
## Bug Fix
Fixes a critical bug in the installer script where color codes were contaminating the version string, causing download URLs to be malformed.

**Before:**


**After:**  


## New Feature
Adds prominent "Quick Install" section to README with one-liner installation commands:

- **Linux/macOS**: `curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash`
- **Windows**: `iwr -useb https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.ps1 | iex`
- **Beta releases**: `curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash -s -- --beta`

## Testing
- ✅ Tested install script with `--dry-run --beta` 
- ✅ Successfully downloads and verifies 1.0.0-beta1 release
- ✅ Correctly identifies platform and binary version