### PR TITLE
Add uninstall functionality and prepare v1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ dotnet run --project src/FreshdeskCLI -- --help
 
 Download the latest release for your platform from the [Releases](https://github.com/Aaronontheweb/freshdesk-cli/releases) page.
 
+## Uninstallation
+
+**Remove Freshdesk CLI:**
+```bash
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash -s -- --uninstall
+```
+
+This will:
+- Remove the `freshdesk` binary from your installation directory
+- Optionally remove the configuration directory (`~/.freshdesk`) if you choose
+- Optionally remove the installation directory if it becomes empty
+
 ## Configuration
 
 ### Initial Setup

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,61 @@
+#### 1.0.0 August 14th 2025 ####
+
+**First Stable Release**
+
+The first stable release of the Freshdesk CLI tool - a powerful command-line interface for managing Freshdesk tickets and support operations.
+
+**New Features:**
+- **Uninstall Support** - Easy removal via `curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash -s -- --uninstall`
+- **Improved Installation** - One-command installation with proper error handling and version detection
+- **Stable Release Channel** - No more beta flags needed for installation
+
+**Features:**
+- **Configuration Management** - Set and test Freshdesk API credentials
+- **Ticket Operations** - List, view, create, update, and search tickets
+- **Conversation Support** - Reply to tickets and add internal notes
+- **Attachment Handling** - List, download (bulk support), and upload attachments
+- **Export Functionality** - Export tickets to JSON, CSV, XML, or Markdown formats
+- **Self-Update Mechanism** - Built-in update command to fetch latest releases
+- **Read-Only Mode** - Safe mode for viewing without making changes
+- **Cross-Platform** - Native binaries for Linux and macOS (x64 and ARM64)
+- **AOT Compilation** - Fast startup and minimal memory footprint using .NET 9 AOT
+
+**Installation:**
+```bash
+# Quick install
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash
+
+# Uninstall
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash -s -- --uninstall
+```
+
+**Technical Highlights:**
+- Built with .NET 9 and AOT (Ahead-of-Time) compilation
+- Reflection-free JSON serialization for optimal performance
+- Progress indicators for long-running operations
+- Comprehensive error handling and validation
+
+**Platform Support:**
+- Linux x64
+- macOS x64 (Intel)
+- macOS ARM64 (Apple Silicon)
+- Windows x64 (manual download from releases page)
+
+**Getting Started:**
+```bash
+# Configure your Freshdesk credentials
+freshdesk config set --domain your-domain --api-key your-api-key
+
+# Test the connection
+freshdesk config test
+
+# List recent tickets
+freshdesk ticket list
+
+# Get help
+freshdesk --help
+```
+
 #### 1.0.0-beta1 August 14th 2025 ####
 
 **Initial Beta Release**

--- a/install.sh
+++ b/install.sh
@@ -187,11 +187,66 @@ check_path() {
     fi
 }
 
+# Uninstall Freshdesk CLI
+uninstall_freshdesk() {
+    echo "==================================="
+    echo "  Freshdesk CLI Uninstaller"
+    echo "==================================="
+    echo ""
+    
+    local binary_path="${INSTALL_DIR}/${BINARY_NAME}"
+    local config_dir="${HOME}/.freshdesk"
+    local removed_something=false
+    
+    # Remove binary
+    if [ -f "$binary_path" ]; then
+        info "Removing binary from $binary_path"
+        rm "$binary_path" || error "Failed to remove binary"
+        info "Binary removed successfully"
+        removed_something=true
+    else
+        warn "Binary not found at $binary_path"
+    fi
+    
+    # Ask about config removal
+    if [ -d "$config_dir" ]; then
+        echo ""
+        echo -n "Remove configuration directory $config_dir? [y/N]: "
+        read -r response
+        if [[ "$response" =~ ^[Yy]$ ]]; then
+            rm -rf "$config_dir" || error "Failed to remove configuration directory"
+            info "Configuration directory removed"
+            removed_something=true
+        else
+            info "Configuration directory preserved"
+        fi
+    fi
+    
+    echo ""
+    if [ "$removed_something" = true ]; then
+        info "Uninstall completed successfully"
+    else
+        warn "Nothing was removed - Freshdesk CLI may not have been installed"
+    fi
+    
+    # Check if install directory is now empty and removable
+    if [ -d "$INSTALL_DIR" ] && [ -z "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
+        echo ""
+        echo -n "Remove empty installation directory $INSTALL_DIR? [y/N]: "
+        read -r response
+        if [[ "$response" =~ ^[Yy]$ ]]; then
+            rmdir "$INSTALL_DIR" 2>/dev/null && info "Installation directory removed" || warn "Could not remove installation directory"
+        fi
+    fi
+}
+
 # Main installation flow
 main() {
     # Parse command line arguments
     local dry_run=false
     local include_beta=false
+    local uninstall=false
+    
     for arg in "$@"; do
         case $arg in
             --dry-run|--dry|-n)
@@ -200,12 +255,16 @@ main() {
             --beta|--pre|--prerelease)
                 include_beta=true
                 ;;
+            --uninstall|--remove)
+                uninstall=true
+                ;;
             --help|-h)
                 echo "Usage: $0 [OPTIONS]"
                 echo ""
                 echo "Options:"
                 echo "  --dry-run, -n       Download and verify but don't install"
                 echo "  --beta, --pre       Include beta/pre-release versions"
+                echo "  --uninstall         Remove Freshdesk CLI and optionally config"
                 echo "  --help, -h          Show this help message"
                 echo ""
                 echo "Environment variables:"
@@ -214,6 +273,12 @@ main() {
                 ;;
         esac
     done
+    
+    # Handle uninstall
+    if [ "$uninstall" = true ]; then
+        uninstall_freshdesk
+        exit 0
+    fi
     
     echo "==================================="
     echo "  Freshdesk CLI Installer"


### PR DESCRIPTION
## New Feature: Uninstall Support

Implements uninstall functionality as requested in #24.

### Changes

**Installer Script ():**
- ✅ Added `--uninstall` flag to argument parsing
- ✅ Implemented `uninstall_freshdesk()` function with interactive prompts
- ✅ Removes binary from installation directory
- ✅ Optionally removes configuration directory (`~/.freshdesk`)
- ✅ Optionally removes empty installation directory
- ✅ Updated help text to include uninstall option

**README.md:**
- ✅ Added "Uninstallation" section with usage instructions
- ✅ Clear documentation of what gets removed

**RELEASE_NOTES.md:**
- ✅ Added v1.0.0 release notes with uninstall feature
- ✅ Comprehensive feature list and installation instructions
- ✅ Ready for stable release

### Usage

```bash
# Uninstall via curl one-liner
curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash -s -- --uninstall

# Or download and run locally
./install.sh --uninstall
```

### Testing

- ✅ Tested `--help` shows new uninstall option
- ✅ Tested uninstall with no installation (graceful handling)
- ✅ Interactive prompts work correctly for config/directory removal

### Ready for v1.0.0

This PR includes everything needed for the v1.0.0 stable release:
- Uninstall functionality (resolves #24)
- Updated documentation
- Comprehensive release notes

Closes #24