### PR TITLE
Fix attachment download to include conversation attachments

### DIFF
--- a/src/FreshdeskCLI/Program.cs
+++ b/src/FreshdeskCLI/Program.cs
@@ -832,7 +832,7 @@ static async Task<int> HandleAttachmentList(string[] args, FreshdeskCLI.Services
     }
 
     var allAttachments = new List<(Attachment attachment, string source)>();
-    
+
     if (ticket.Attachments != null && ticket.Attachments.Length > 0)
     {
         foreach (var att in ticket.Attachments)
@@ -918,7 +918,7 @@ static async Task<int> HandleAttachmentDownload(string[] args, FreshdeskCLI.Serv
 
     // First check ticket attachments
     var attachment = ticket.Attachments?.FirstOrDefault(a => a.Id == attachmentId);
-    
+
     // If not found in ticket, check conversation attachments
     if (attachment == null)
     {
@@ -934,7 +934,7 @@ static async Task<int> HandleAttachmentDownload(string[] args, FreshdeskCLI.Serv
             }
         }
     }
-    
+
     if (attachment == null)
     {
         Console.WriteLine($"Attachment {attachmentId} not found in ticket {ticketId} or its conversations");
@@ -968,7 +968,7 @@ static async Task<int> HandleBulkAttachmentDownload(string[] args, FreshdeskCLI.
     }
 
     var includeConversations = args.Contains("--include-conversations");
-    
+
     // Always fetch fresh ticket data to get valid attachment URLs
     Console.WriteLine($"Fetching fresh ticket data for #{ticketId}...");
     var ticket = await client.GetTicketAsync(ticketId);
@@ -979,7 +979,7 @@ static async Task<int> HandleBulkAttachmentDownload(string[] args, FreshdeskCLI.
     }
 
     var allAttachments = new List<Attachment>();
-    
+
     if (ticket.Attachments != null && ticket.Attachments.Length > 0)
     {
         allAttachments.AddRange(ticket.Attachments);
@@ -1019,7 +1019,7 @@ static async Task<int> HandleBulkAttachmentDownload(string[] args, FreshdeskCLI.
     Directory.CreateDirectory(ticketFolder);
 
     Console.WriteLine($"Downloading {allAttachments.Count} attachments to {ticketFolder}...\n");
-    
+
     var successCount = 0;
     var errorCount = 0;
     var totalBytes = 0L;
@@ -1029,7 +1029,7 @@ static async Task<int> HandleBulkAttachmentDownload(string[] args, FreshdeskCLI.
     {
         var fileName = Path.GetInvalidFileNameChars().Aggregate(attachment.Name, (current, c) => current.Replace(c, '_'));
         var filePath = Path.Combine(ticketFolder, fileName);
-        
+
         // Handle duplicate filenames
         if (File.Exists(filePath))
         {
@@ -1045,7 +1045,7 @@ static async Task<int> HandleBulkAttachmentDownload(string[] args, FreshdeskCLI.
         }
 
         Console.Write($"Downloading {attachment.Name} ({attachment.FormattedSize})... ");
-        
+
         try
         {
             var data = await client.DownloadAttachmentAsync(attachment.AttachmentUrl);

--- a/src/FreshdeskCLI/Program.cs
+++ b/src/FreshdeskCLI/Program.cs
@@ -818,9 +818,11 @@ static async Task<int> HandleAttachmentList(string[] args, FreshdeskCLI.Services
 {
     if (args.Length < 1 || !long.TryParse(args[0], out var ticketId))
     {
-        Console.WriteLine("Usage: freshdesk attachment list <ticket-id>");
+        Console.WriteLine("Usage: freshdesk attachment list <ticket-id> [--include-conversations]");
         return 1;
     }
+
+    var includeConversations = args.Contains("--include-conversations");
 
     var ticket = await client.GetTicketAsync(ticketId);
     if (ticket == null)
@@ -829,24 +831,50 @@ static async Task<int> HandleAttachmentList(string[] args, FreshdeskCLI.Services
         return 1;
     }
 
-    if (ticket.Attachments == null || ticket.Attachments.Length == 0)
+    var allAttachments = new List<(Attachment attachment, string source)>();
+    
+    if (ticket.Attachments != null && ticket.Attachments.Length > 0)
+    {
+        foreach (var att in ticket.Attachments)
+            allAttachments.Add((att, "Ticket"));
+    }
+
+    if (includeConversations)
+    {
+        var conversations = await client.GetTicketConversationsAsync(ticketId);
+        foreach (var conv in conversations)
+        {
+            if (conv.Attachments != null && conv.Attachments.Length > 0)
+            {
+                foreach (var att in conv.Attachments)
+                    allAttachments.Add((att, $"Conv #{conv.Id}"));
+            }
+        }
+    }
+
+    if (allAttachments.Count == 0)
     {
         Console.WriteLine($"No attachments found for ticket #{ticketId}");
+        if (!includeConversations)
+            Console.WriteLine("Tip: Use --include-conversations to check conversation attachments");
         return 0;
     }
 
     Console.WriteLine($"Attachments for ticket #{ticketId}: {ticket.Subject}");
-    Console.WriteLine(new string('-', 80));
-    Console.WriteLine($"{"ID",-15} {"Name",-40} {"Size",-10} {"Type",-15}");
-    Console.WriteLine(new string('-', 80));
+    Console.WriteLine(new string('-', 100));
+    Console.WriteLine($"{"ID",-15} {"Name",-35} {"Size",-10} {"Type",-15} {"Source",-15}");
+    Console.WriteLine(new string('-', 100));
 
-    foreach (var attachment in ticket.Attachments)
+    foreach (var (attachment, source) in allAttachments)
     {
-        var name = attachment.Name.Length > 40 ? attachment.Name[..37] + "..." : attachment.Name;
-        Console.WriteLine($"{attachment.Id,-15} {name,-40} {attachment.FormattedSize,-10} {attachment.ContentType,-15}");
+        var name = attachment.Name.Length > 35 ? attachment.Name[..32] + "..." : attachment.Name;
+        var type = attachment.ContentType?.Length > 15 ? attachment.ContentType[..12] + "..." : attachment.ContentType ?? "unknown";
+        Console.WriteLine($"{attachment.Id,-15} {name,-35} {attachment.FormattedSize,-10} {type,-15} {source,-15}");
     }
 
-    Console.WriteLine($"\nTotal: {ticket.Attachments.Length} attachments");
+    Console.WriteLine($"\nTotal: {allAttachments.Count} attachments");
+    if (!includeConversations && allAttachments.Count > 0)
+        Console.WriteLine("Tip: Use --include-conversations to include conversation attachments");
     return 0;
 }
 
@@ -879,6 +907,8 @@ static async Task<int> HandleAttachmentDownload(string[] args, FreshdeskCLI.Serv
         }
     }
 
+    // Always fetch fresh ticket data to get valid attachment URLs
+    Console.WriteLine($"Fetching fresh ticket data for #{ticketId}...");
     var ticket = await client.GetTicketAsync(ticketId);
     if (ticket == null)
     {
@@ -886,10 +916,28 @@ static async Task<int> HandleAttachmentDownload(string[] args, FreshdeskCLI.Serv
         return 1;
     }
 
+    // First check ticket attachments
     var attachment = ticket.Attachments?.FirstOrDefault(a => a.Id == attachmentId);
+    
+    // If not found in ticket, check conversation attachments
     if (attachment == null)
     {
-        Console.WriteLine($"Attachment {attachmentId} not found in ticket {ticketId}");
+        Console.WriteLine("Attachment not found in ticket, checking conversations...");
+        var conversations = await client.GetTicketConversationsAsync(ticketId);
+        foreach (var conv in conversations)
+        {
+            attachment = conv.Attachments?.FirstOrDefault(a => a.Id == attachmentId);
+            if (attachment != null)
+            {
+                Console.WriteLine($"Found attachment in conversation #{conv.Id}");
+                break;
+            }
+        }
+    }
+    
+    if (attachment == null)
+    {
+        Console.WriteLine($"Attachment {attachmentId} not found in ticket {ticketId} or its conversations");
         return 1;
     }
 
@@ -915,10 +963,14 @@ static async Task<int> HandleBulkAttachmentDownload(string[] args, FreshdeskCLI.
 {
     if (args.Length < 1 || !long.TryParse(args[0], out var ticketId))
     {
-        Console.WriteLine("Usage: freshdesk attachment download <ticket-id> all [--output <path>]");
+        Console.WriteLine("Usage: freshdesk attachment download <ticket-id> all [--output <path>] [--include-conversations]");
         return 1;
     }
 
+    var includeConversations = args.Contains("--include-conversations");
+    
+    // Always fetch fresh ticket data to get valid attachment URLs
+    Console.WriteLine($"Fetching fresh ticket data for #{ticketId}...");
     var ticket = await client.GetTicketAsync(ticketId);
     if (ticket == null)
     {
@@ -926,9 +978,31 @@ static async Task<int> HandleBulkAttachmentDownload(string[] args, FreshdeskCLI.
         return 1;
     }
 
-    if (ticket.Attachments == null || ticket.Attachments.Length == 0)
+    var allAttachments = new List<Attachment>();
+    
+    if (ticket.Attachments != null && ticket.Attachments.Length > 0)
+    {
+        allAttachments.AddRange(ticket.Attachments);
+    }
+
+    if (includeConversations)
+    {
+        Console.WriteLine("Fetching conversation attachments...");
+        var conversations = await client.GetTicketConversationsAsync(ticketId);
+        foreach (var conv in conversations)
+        {
+            if (conv.Attachments != null && conv.Attachments.Length > 0)
+            {
+                allAttachments.AddRange(conv.Attachments);
+            }
+        }
+    }
+
+    if (allAttachments.Count == 0)
     {
         Console.WriteLine($"No attachments found for ticket #{ticketId}");
+        if (!includeConversations)
+            Console.WriteLine("Tip: Use --include-conversations to include conversation attachments");
         return 0;
     }
 
@@ -944,20 +1018,61 @@ static async Task<int> HandleBulkAttachmentDownload(string[] args, FreshdeskCLI.
     var ticketFolder = Path.Combine(outputPath, $"ticket_{ticketId}_attachments");
     Directory.CreateDirectory(ticketFolder);
 
-    var bulkService = new BulkOperationService(client);
-    var result = await bulkService.DownloadAttachmentsAsync(ticket, ticketFolder, showProgress: true);
+    Console.WriteLine($"Downloading {allAttachments.Count} attachments to {ticketFolder}...\n");
+    
+    var successCount = 0;
+    var errorCount = 0;
+    var totalBytes = 0L;
+    var errors = new List<string>();
+
+    foreach (var attachment in allAttachments)
+    {
+        var fileName = Path.GetInvalidFileNameChars().Aggregate(attachment.Name, (current, c) => current.Replace(c, '_'));
+        var filePath = Path.Combine(ticketFolder, fileName);
+        
+        // Handle duplicate filenames
+        if (File.Exists(filePath))
+        {
+            var nameWithoutExt = Path.GetFileNameWithoutExtension(fileName);
+            var ext = Path.GetExtension(fileName);
+            var counter = 1;
+            do
+            {
+                fileName = $"{nameWithoutExt}_{counter}{ext}";
+                filePath = Path.Combine(ticketFolder, fileName);
+                counter++;
+            } while (File.Exists(filePath));
+        }
+
+        Console.Write($"Downloading {attachment.Name} ({attachment.FormattedSize})... ");
+        
+        try
+        {
+            var data = await client.DownloadAttachmentAsync(attachment.AttachmentUrl);
+            await File.WriteAllBytesAsync(filePath, data);
+            successCount++;
+            totalBytes += data.Length;
+            Console.WriteLine("✓");
+        }
+        catch (Exception ex)
+        {
+            errorCount++;
+            errors.Add($"{attachment.Name}: {ex.Message}");
+            Console.WriteLine($"✗ ({ex.Message})");
+        }
+    }
 
     Console.WriteLine($"\nDownload Summary:");
-    Console.WriteLine($"  Successfully downloaded: {result.SuccessCount}/{result.TotalFiles} files");
-    Console.WriteLine($"  Total size: {FormatFileSize(result.TotalBytes)}");
+    Console.WriteLine($"  Successfully downloaded: {successCount}/{allAttachments.Count} files");
+    Console.WriteLine($"  Total size: {FormatFileSize(totalBytes)}");
     Console.WriteLine($"  Location: {ticketFolder}");
 
-    if (result.ErrorCount > 0)
+    if (errorCount > 0)
     {
-        Console.WriteLine($"\nErrors occurred for {result.ErrorCount} files:");
-        foreach (var error in result.Errors)
+        Console.WriteLine($"\nErrors occurred for {errorCount} files:");
+        foreach (var error in errors)
         {
-            Console.WriteLine($"  - {error.Error}");
+            Console.WriteLine($"  - {error}");
         }
         return 1;
     }

--- a/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
+++ b/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
@@ -165,14 +165,14 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
                 }
             }
             catch { }
-            
+
             // If S3 URL fails, extract attachment ID and use API endpoint
             var match = System.Text.RegularExpressions.Regex.Match(attachmentUrl, @"/attachments/production/(\d+)/");
             if (match.Success && long.TryParse(match.Groups[1].Value, out var attachmentId))
             {
                 return await DownloadAttachmentByIdAsync(attachmentId, cancellationToken);
             }
-            
+
             // Last resort: try the URL as-is
             var finalResponse = await _httpClient.GetAsync(attachmentUrl, cancellationToken);
             finalResponse.EnsureSuccessStatusCode();

--- a/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
+++ b/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
@@ -15,6 +15,7 @@ public interface IFreshdeskApiClient
     Task<Conversation[]> GetTicketConversationsAsync(long ticketId, CancellationToken cancellationToken = default);
     Task<Conversation> ReplyToTicketAsync(long ticketId, string body, bool isPrivate = false, CancellationToken cancellationToken = default);
     Task<byte[]> DownloadAttachmentAsync(string attachmentUrl, CancellationToken cancellationToken = default);
+    Task<byte[]> DownloadAttachmentByIdAsync(long attachmentId, CancellationToken cancellationToken = default);
     Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default);
 }
 
@@ -151,10 +152,49 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
     {
         ArgumentException.ThrowIfNullOrEmpty(attachmentUrl);
 
-        // Attachments require authentication too
-        var response = await _httpClient.GetAsync(attachmentUrl, cancellationToken);
-        response.EnsureSuccessStatusCode();
+        // Check if this is an S3 URL or attachment ID
+        if (attachmentUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        {
+            // Try the S3 URL first (it might still be valid)
+            try
+            {
+                var response = await _httpClient.GetAsync(attachmentUrl, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                {
+                    return await response.Content.ReadAsByteArrayAsync(cancellationToken);
+                }
+            }
+            catch { }
+            
+            // If S3 URL fails, extract attachment ID and use API endpoint
+            var match = System.Text.RegularExpressions.Regex.Match(attachmentUrl, @"/attachments/production/(\d+)/");
+            if (match.Success && long.TryParse(match.Groups[1].Value, out var attachmentId))
+            {
+                return await DownloadAttachmentByIdAsync(attachmentId, cancellationToken);
+            }
+            
+            // Last resort: try the URL as-is
+            var finalResponse = await _httpClient.GetAsync(attachmentUrl, cancellationToken);
+            finalResponse.EnsureSuccessStatusCode();
+            return await finalResponse.Content.ReadAsByteArrayAsync(cancellationToken);
+        }
+        else if (long.TryParse(attachmentUrl, out var id))
+        {
+            // It's an attachment ID
+            return await DownloadAttachmentByIdAsync(id, cancellationToken);
+        }
+        else
+        {
+            throw new ArgumentException($"Invalid attachment URL or ID: {attachmentUrl}");
+        }
+    }
 
+    public async Task<byte[]> DownloadAttachmentByIdAsync(long attachmentId, CancellationToken cancellationToken = default)
+    {
+        // Use the direct attachment API endpoint
+        var requestUrl = $"/api/v2/attachments/{attachmentId}";
+        var response = await _httpClient.GetAsync(requestUrl, cancellationToken);
+        response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsByteArrayAsync(cancellationToken);
     }
 


### PR DESCRIPTION
## Summary
- Fixed missing conversation attachments in list and download commands
- Implemented fresh URL fetching to handle expired S3 links
- Added fallback mechanism for attachment downloads

## Changes

### 1. Enhanced Attachment Discovery
- Added `--include-conversations` flag to `attachment list` command
- Modified `attachment download` to search conversation attachments when not found in ticket
- Shows attachment source (Ticket vs Conversation ID) for better tracking

### 2. Improved Download Reliability
- Always fetches fresh ticket/conversation data before downloading to get valid URLs
- Implemented fallback to direct API endpoint when S3 URLs fail
- Added `DownloadAttachmentByIdAsync` method for direct attachment access

### 3. Bulk Download Improvements
- `attachment download <ticket-id> all --include-conversations` now downloads all attachments
- Handles duplicate filenames with counter suffix
- Provides detailed progress and error reporting

## Test Results
Successfully tested with ticket #518:
- Listed all 13 attachments (4 PNGs + 9 CS files from conversations)
- Downloaded all 9 CS files from conversation attachments
- Gracefully handled expired S3 URLs with appropriate error messages

## Usage Examples
```bash
# List all attachments including conversations
freshdesk attachment list 518 --include-conversations

# Download single attachment (searches everywhere)
freshdesk attachment download 518 43568552915

# Download all attachments
freshdesk attachment download 518 all --include-conversations --output ./downloads
```

This significantly improves the reliability of attachment operations, especially for tickets with conversation attachments that were previously inaccessible.