### PR TITLE
Fix ticket reply 400 Bad Request error (#39)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,33 @@
+#### 1.0.4 August 15th 2025 ####
+
+**Critical Bug Fix Release**
+
+This release fixes a critical bug that prevented users from replying to tickets.
+
+**Bug Fixes:**
+- **Fixed Ticket Reply 400 Bad Request Error** (#39)
+  - Corrected API endpoint usage: `/reply` for public replies, `/notes` for private notes
+  - Removed invalid `private` field from reply requests
+  - Public replies and private notes now work correctly
+  - Added comprehensive test coverage for both reply types
+
+**Installation:**
+Update using the self-update command:
+```bash
+freshdesk update
+```
+
+Or use the one-command installer:
+```bash
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash
+```
+
+**Platform Support:**
+- Linux x64
+- macOS x64 (Intel)
+- macOS ARM64 (Apple Silicon)
+- Windows x64
+
 #### 1.0.2 August 15th 2025 ####
 
 **Bug Fix and Enhancement Release**

--- a/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
+++ b/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
@@ -153,17 +153,22 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
     {
         ArgumentException.ThrowIfNullOrEmpty(body);
 
-        // Create a dictionary for the reply since we don't have a specific model
-        var reply = new Dictionary<string, object>
+        var endpoint = isPrivate ? $"/api/v2/tickets/{ticketId}/notes" : $"/api/v2/tickets/{ticketId}/reply";
+
+        var requestBody = new Dictionary<string, object>
         {
-            ["body"] = body,
-            ["private"] = isPrivate
+            ["body"] = body
         };
 
-        var json = JsonSerializer.Serialize(reply, FreshdeskJsonContext.Default.DictionaryStringObject);
+        if (isPrivate)
+        {
+            requestBody["private"] = true;
+        }
+
+        var json = JsonSerializer.Serialize(requestBody, FreshdeskJsonContext.Default.DictionaryStringObject);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-        var response = await _httpClient.PostAsync($"/api/v2/tickets/{ticketId}/reply", content, cancellationToken);
+        var response = await _httpClient.PostAsync(endpoint, content, cancellationToken);
         response.EnsureSuccessStatusCode();
 
         var responseJson = await response.Content.ReadAsStringAsync(cancellationToken);

--- a/tests/FreshdeskCLI.Tests/Integration/EndToEndTests.cs
+++ b/tests/FreshdeskCLI.Tests/Integration/EndToEndTests.cs
@@ -310,6 +310,47 @@ public class EndToEndTests : IDisposable
     }
 
     [Fact]
+    public async Task AddPrivateNote_AddsInternalNote()
+    {
+        // Arrange
+        var config = new FreshdeskConfig
+        {
+            Domain = "test",
+            ApiKey = "test-api-key-12345"
+        };
+
+        var client = new FreshdeskApiClient(config, _httpClient);
+
+        var noteConversation = new Conversation
+        {
+            Body = "This is a private internal note",
+            Private = true
+        };
+
+        var createdNote = new Conversation
+        {
+            Id = 1000,
+            Body = noteConversation.Body,
+            BodyText = "This is a private internal note",
+            Private = true,
+            Incoming = false,
+            CreatedAt = DateTimeOffset.Now
+        };
+
+        _mockServer.SetupAddNoteToTicket(123, noteConversation, createdNote);
+
+        // Act
+        var result = await client.ReplyToTicketAsync(123, "This is a private internal note", true);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(1000, result.Id);
+        Assert.Equal("This is a private internal note", result.BodyText);
+        Assert.True(result.Private);
+        Assert.False(result.Incoming);
+    }
+
+    [Fact]
     public async Task DownloadAttachment_SavesFile()
     {
         // Arrange

--- a/tests/FreshdeskCLI.Tests/Integration/MockFreshdeskServer.cs
+++ b/tests/FreshdeskCLI.Tests/Integration/MockFreshdeskServer.cs
@@ -116,6 +116,12 @@ public class MockFreshdeskServer : HttpMessageHandler
         _statusCodes[$"POST:/api/v2/tickets/{ticketId}/reply"] = HttpStatusCode.Created;
     }
 
+    public void SetupAddNoteToTicket(long ticketId, Conversation note, Conversation createdNote)
+    {
+        _responses[$"POST:/api/v2/tickets/{ticketId}/notes"] = createdNote;
+        _statusCodes[$"POST:/api/v2/tickets/{ticketId}/notes"] = HttpStatusCode.Created;
+    }
+
     public void SetupAttachmentDownload(string url, byte[] content)
     {
         var uri = new Uri(url);


### PR DESCRIPTION
## Summary
Fixes #39 - The `freshdesk ticket reply` command was failing with a 400 Bad Request error when attempting to add replies to open tickets.

## Root Cause
The API client was incorrectly sending a `private` field to the `/api/v2/tickets/{id}/reply` endpoint, which doesn't accept this field and resulted in a 400 Bad Request error.

## Changes
- Modified `ReplyToTicketAsync` method to use correct endpoints:
  - `/api/v2/tickets/{id}/reply` for public replies (without `private` field)
  - `/api/v2/tickets/{id}/notes` for private notes (with `private` field)
- Only include `body` field in request for public replies
- Added test infrastructure support for notes endpoint
- Added test coverage for private notes functionality

## Testing
- ✅ All existing tests pass
- ✅ Added new test `AddPrivateNote_AddsInternalNote` 
- ✅ Manually tested with ticket 528:
  - Successfully added public reply (ID: 43947584535)
  - Successfully added private note (ID: 43947584556)
  - Both appear correctly in ticket conversation tree

## Release Notes
Added 1.0.4 release notes documenting this critical bug fix.