### PR TITLE
Improve filter parsing and ticket list display

### DIFF
--- a/src/FreshdeskCLI/Helpers/EnumParser.cs
+++ b/src/FreshdeskCLI/Helpers/EnumParser.cs
@@ -7,12 +7,12 @@ public static class EnumParser
     public static bool TryParseTicketStatus(string input, out TicketStatus status)
     {
         status = TicketStatus.None;
-        
+
         if (string.IsNullOrWhiteSpace(input))
             return false;
-        
+
         var normalizedInput = input.Replace(" ", "").Replace("_", "").Replace("-", "").ToLowerInvariant();
-        
+
         var statusMappings = new Dictionary<string, TicketStatus>(StringComparer.OrdinalIgnoreCase)
         {
             { "open", TicketStatus.Open },
@@ -32,13 +32,13 @@ public static class EnumParser
             { "6", TicketStatus.WaitingOnCustomer },
             { "7", TicketStatus.WaitingOnThirdParty }
         };
-        
+
         if (statusMappings.TryGetValue(normalizedInput, out status))
             return true;
-        
+
         if (Enum.TryParse<TicketStatus>(input, true, out status) && status != TicketStatus.None && Enum.IsDefined(typeof(TicketStatus), status))
             return true;
-            
+
         return false;
     }
 
@@ -50,12 +50,12 @@ public static class EnumParser
     public static bool TryParseTicketPriority(string input, out TicketPriority priority)
     {
         priority = TicketPriority.None;
-        
+
         if (string.IsNullOrWhiteSpace(input))
             return false;
-        
+
         var normalizedInput = input.ToLowerInvariant();
-        
+
         var priorityMappings = new Dictionary<string, TicketPriority>(StringComparer.OrdinalIgnoreCase)
         {
             { "low", TicketPriority.Low },
@@ -67,13 +67,13 @@ public static class EnumParser
             { "3", TicketPriority.High },
             { "4", TicketPriority.Urgent }
         };
-        
+
         if (priorityMappings.TryGetValue(normalizedInput, out priority))
             return true;
-        
+
         if (Enum.TryParse<TicketPriority>(input, true, out priority) && priority != TicketPriority.None && Enum.IsDefined(typeof(TicketPriority), priority))
             return true;
-            
+
         return false;
     }
 

--- a/src/FreshdeskCLI/Helpers/EnumParser.cs
+++ b/src/FreshdeskCLI/Helpers/EnumParser.cs
@@ -1,0 +1,84 @@
+using FreshdeskCLI.Models;
+
+namespace FreshdeskCLI.Helpers;
+
+public static class EnumParser
+{
+    public static bool TryParseTicketStatus(string input, out TicketStatus status)
+    {
+        status = TicketStatus.None;
+        
+        if (string.IsNullOrWhiteSpace(input))
+            return false;
+        
+        var normalizedInput = input.Replace(" ", "").Replace("_", "").Replace("-", "").ToLowerInvariant();
+        
+        var statusMappings = new Dictionary<string, TicketStatus>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "open", TicketStatus.Open },
+            { "pending", TicketStatus.Pending },
+            { "resolved", TicketStatus.Resolved },
+            { "closed", TicketStatus.Closed },
+            { "waitingoncustomer", TicketStatus.WaitingOnCustomer },
+            { "waitingcustomer", TicketStatus.WaitingOnCustomer },
+            { "customerwait", TicketStatus.WaitingOnCustomer },
+            { "waitingonthirdparty", TicketStatus.WaitingOnThirdParty },
+            { "waitingthirdparty", TicketStatus.WaitingOnThirdParty },
+            { "thirdpartywait", TicketStatus.WaitingOnThirdParty },
+            { "2", TicketStatus.Open },
+            { "3", TicketStatus.Pending },
+            { "4", TicketStatus.Resolved },
+            { "5", TicketStatus.Closed },
+            { "6", TicketStatus.WaitingOnCustomer },
+            { "7", TicketStatus.WaitingOnThirdParty }
+        };
+        
+        if (statusMappings.TryGetValue(normalizedInput, out status))
+            return true;
+        
+        if (Enum.TryParse<TicketStatus>(input, true, out status) && status != TicketStatus.None && Enum.IsDefined(typeof(TicketStatus), status))
+            return true;
+            
+        return false;
+    }
+
+    public static string GetValidStatusValues()
+    {
+        return "Valid status values: Open, Pending, Resolved, Closed, WaitingOnCustomer, WaitingOnThirdParty";
+    }
+
+    public static bool TryParseTicketPriority(string input, out TicketPriority priority)
+    {
+        priority = TicketPriority.None;
+        
+        if (string.IsNullOrWhiteSpace(input))
+            return false;
+        
+        var normalizedInput = input.ToLowerInvariant();
+        
+        var priorityMappings = new Dictionary<string, TicketPriority>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "low", TicketPriority.Low },
+            { "medium", TicketPriority.Medium },
+            { "high", TicketPriority.High },
+            { "urgent", TicketPriority.Urgent },
+            { "1", TicketPriority.Low },
+            { "2", TicketPriority.Medium },
+            { "3", TicketPriority.High },
+            { "4", TicketPriority.Urgent }
+        };
+        
+        if (priorityMappings.TryGetValue(normalizedInput, out priority))
+            return true;
+        
+        if (Enum.TryParse<TicketPriority>(input, true, out priority) && priority != TicketPriority.None && Enum.IsDefined(typeof(TicketPriority), priority))
+            return true;
+            
+        return false;
+    }
+
+    public static string GetValidPriorityValues()
+    {
+        return "Valid priority values: Low, Medium, High, Urgent";
+    }
+}

--- a/src/FreshdeskCLI/Helpers/OutputFormatter.cs
+++ b/src/FreshdeskCLI/Helpers/OutputFormatter.cs
@@ -31,13 +31,13 @@ public static class OutputFormatter
             return;
         }
 
-        Console.WriteLine($"{"ID",-10} {"Subject",-30} {"Customer",-25} {"Status",-15} {"Priority",-10} {"Created",-20}");
+        Console.WriteLine($"{"ID",-10} {"Subject",-30} {"Requester Email",-25} {"Status",-15} {"Priority",-10} {"Created",-20}");
         Console.WriteLine(new string('-', 110));
 
         foreach (var ticket in tickets)
         {
             var subject = TruncateString(ticket.Subject ?? "", 30);
-            var email = TruncateString(ticket.Email ?? "", 25);
+            var email = TruncateString(ticket.Email ?? "N/A", 25);
             Console.WriteLine($"{ticket.Id,-10} {subject,-30} {email,-25} {ticket.Status,-15} {ticket.Priority,-10} {ticket.CreatedAt:yyyy-MM-dd HH:mm}");
         }
 

--- a/src/FreshdeskCLI/Program.cs
+++ b/src/FreshdeskCLI/Program.cs
@@ -4,6 +4,7 @@ using FreshdeskCLI;
 using FreshdeskCLI.Models;
 using FreshdeskCLI.Helpers;
 using FreshdeskCLI.Services;
+using static FreshdeskCLI.Helpers.EnumParser;
 
 // For now, use a simpler approach without System.CommandLine's complex features
 // System.CommandLine is AOT-compatible but the beta API is still evolving
@@ -310,8 +311,20 @@ static async Task<int> HandleTicketList(string[] args, FreshdeskCLI.Services.Fre
                 break;
             case "--status":
             case "-s":
-                if (i + 1 < args.Length && Enum.TryParse<TicketStatus>(args[++i], true, out var s))
-                    statusFilter = s;
+                if (i + 1 < args.Length)
+                {
+                    var statusArg = args[++i];
+                    if (TryParseTicketStatus(statusArg, out var s))
+                    {
+                        statusFilter = s;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"Invalid status value: '{statusArg}'");
+                        Console.Error.WriteLine(GetValidStatusValues());
+                        return 1;
+                    }
+                }
                 break;
             case "--email":
             case "--customer":
@@ -438,8 +451,20 @@ static async Task<int> HandleTicketCreate(string[] args, FreshdeskCLI.Services.F
                 break;
             case "--priority":
             case "-p":
-                if (i + 1 < args.Length && Enum.TryParse<TicketPriority>(args[++i], true, out var p))
-                    priority = p;
+                if (i + 1 < args.Length)
+                {
+                    var priorityArg = args[++i];
+                    if (TryParseTicketPriority(priorityArg, out var p))
+                    {
+                        priority = p;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"Invalid priority value: '{priorityArg}'");
+                        Console.Error.WriteLine(GetValidPriorityValues());
+                        return 1;
+                    }
+                }
                 break;
         }
     }
@@ -502,13 +527,37 @@ static async Task<int> HandleTicketUpdate(string[] args, FreshdeskCLI.Services.F
         {
             case "--status":
             case "-s":
-                if (i + 1 < args.Length && Enum.TryParse<TicketStatus>(args[++i], true, out var s))
-                    status = s;
+                if (i + 1 < args.Length)
+                {
+                    var statusArg = args[++i];
+                    if (TryParseTicketStatus(statusArg, out var s))
+                    {
+                        status = s;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"Invalid status value: '{statusArg}'");
+                        Console.Error.WriteLine(GetValidStatusValues());
+                        return 1;
+                    }
+                }
                 break;
             case "--priority":
             case "-p":
-                if (i + 1 < args.Length && Enum.TryParse<TicketPriority>(args[++i], true, out var p))
-                    priority = p;
+                if (i + 1 < args.Length)
+                {
+                    var priorityArg = args[++i];
+                    if (TryParseTicketPriority(priorityArg, out var p))
+                    {
+                        priority = p;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"Invalid priority value: '{priorityArg}'");
+                        Console.Error.WriteLine(GetValidPriorityValues());
+                        return 1;
+                    }
+                }
                 break;
         }
     }
@@ -559,13 +608,37 @@ static async Task<int> HandleTicketSearch(string[] args, FreshdeskCLI.Services.F
                 break;
             case "--status":
             case "-s":
-                if (i + 1 < args.Length && Enum.TryParse<TicketStatus>(args[++i], true, out var s))
-                    statusFilter = s;
+                if (i + 1 < args.Length)
+                {
+                    var statusArg = args[++i];
+                    if (TryParseTicketStatus(statusArg, out var s))
+                    {
+                        statusFilter = s;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"Invalid status value: '{statusArg}'");
+                        Console.Error.WriteLine(GetValidStatusValues());
+                        return 1;
+                    }
+                }
                 break;
             case "--priority":
             case "-p":
-                if (i + 1 < args.Length && Enum.TryParse<TicketPriority>(args[++i], true, out var p))
-                    priorityFilter = p;
+                if (i + 1 < args.Length)
+                {
+                    var priorityArg = args[++i];
+                    if (TryParseTicketPriority(priorityArg, out var p))
+                    {
+                        priorityFilter = p;
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine($"Invalid priority value: '{priorityArg}'");
+                        Console.Error.WriteLine(GetValidPriorityValues());
+                        return 1;
+                    }
+                }
                 break;
             case "--email":
             case "--customer":
@@ -1231,13 +1304,13 @@ static async Task<int> HandleExportTickets(string[] args, FreshdeskCLI.Services.
         // Apply filters
         if (!string.IsNullOrEmpty(status))
         {
-            if (Enum.TryParse<TicketStatus>(status, true, out var statusEnum))
+            if (TryParseTicketStatus(status, out var statusEnum))
                 tickets = tickets.Where(t => t.Status == statusEnum).ToArray();
         }
 
         if (!string.IsNullOrEmpty(priority))
         {
-            if (Enum.TryParse<TicketPriority>(priority, true, out var priorityEnum))
+            if (TryParseTicketPriority(priority, out var priorityEnum))
                 tickets = tickets.Where(t => t.Priority == priorityEnum).ToArray();
         }
 

--- a/tests/FreshdeskCLI.Tests/Helpers/EnumParsingTests.cs
+++ b/tests/FreshdeskCLI.Tests/Helpers/EnumParsingTests.cs
@@ -1,0 +1,82 @@
+using Xunit;
+using FreshdeskCLI.Models;
+using FreshdeskCLI.Helpers;
+
+namespace FreshdeskCLI.Tests.Helpers;
+
+public class EnumParsingTests
+{
+
+    [Theory]
+    [InlineData("Open", TicketStatus.Open)]
+    [InlineData("open", TicketStatus.Open)]
+    [InlineData("OPEN", TicketStatus.Open)]
+    [InlineData("2", TicketStatus.Open)]
+    [InlineData("Pending", TicketStatus.Pending)]
+    [InlineData("3", TicketStatus.Pending)]
+    [InlineData("Resolved", TicketStatus.Resolved)]
+    [InlineData("4", TicketStatus.Resolved)]
+    [InlineData("Closed", TicketStatus.Closed)]
+    [InlineData("5", TicketStatus.Closed)]
+    [InlineData("WaitingOnCustomer", TicketStatus.WaitingOnCustomer)]
+    [InlineData("waiting on customer", TicketStatus.WaitingOnCustomer)]
+    [InlineData("waiting-on-customer", TicketStatus.WaitingOnCustomer)]
+    [InlineData("waiting_on_customer", TicketStatus.WaitingOnCustomer)]
+    [InlineData("6", TicketStatus.WaitingOnCustomer)]
+    [InlineData("WaitingOnThirdParty", TicketStatus.WaitingOnThirdParty)]
+    [InlineData("waiting on third party", TicketStatus.WaitingOnThirdParty)]
+    [InlineData("7", TicketStatus.WaitingOnThirdParty)]
+    public void TryParseTicketStatus_ValidInputs_ReturnsCorrectStatus(string input, TicketStatus expected)
+    {
+        var result = EnumParser.TryParseTicketStatus(input, out var status);
+        
+        Assert.True(result);
+        Assert.Equal(expected, status);
+    }
+
+    [Theory]
+    [InlineData("InvalidStatus")]
+    [InlineData("Unknown")]
+    [InlineData("")]
+    [InlineData("99")]
+    [InlineData("OpenClosed")]
+    public void TryParseTicketStatus_InvalidInputs_ReturnsFalse(string input)
+    {
+        var result = EnumParser.TryParseTicketStatus(input, out var status);
+        
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData("Low", TicketPriority.Low)]
+    [InlineData("low", TicketPriority.Low)]
+    [InlineData("LOW", TicketPriority.Low)]
+    [InlineData("1", TicketPriority.Low)]
+    [InlineData("Medium", TicketPriority.Medium)]
+    [InlineData("2", TicketPriority.Medium)]
+    [InlineData("High", TicketPriority.High)]
+    [InlineData("3", TicketPriority.High)]
+    [InlineData("Urgent", TicketPriority.Urgent)]
+    [InlineData("urgent", TicketPriority.Urgent)]
+    [InlineData("4", TicketPriority.Urgent)]
+    public void TryParseTicketPriority_ValidInputs_ReturnsCorrectPriority(string input, TicketPriority expected)
+    {
+        var result = EnumParser.TryParseTicketPriority(input, out var priority);
+        
+        Assert.True(result);
+        Assert.Equal(expected, priority);
+    }
+
+    [Theory]
+    [InlineData("InvalidPriority")]
+    [InlineData("Critical")]
+    [InlineData("")]
+    [InlineData("99")]
+    [InlineData("LowHigh")]
+    public void TryParseTicketPriority_InvalidInputs_ReturnsFalse(string input)
+    {
+        var result = EnumParser.TryParseTicketPriority(input, out var priority);
+        
+        Assert.False(result);
+    }
+}

--- a/tests/FreshdeskCLI.Tests/Helpers/EnumParsingTests.cs
+++ b/tests/FreshdeskCLI.Tests/Helpers/EnumParsingTests.cs
@@ -29,7 +29,7 @@ public class EnumParsingTests
     public void TryParseTicketStatus_ValidInputs_ReturnsCorrectStatus(string input, TicketStatus expected)
     {
         var result = EnumParser.TryParseTicketStatus(input, out var status);
-        
+
         Assert.True(result);
         Assert.Equal(expected, status);
     }
@@ -43,7 +43,7 @@ public class EnumParsingTests
     public void TryParseTicketStatus_InvalidInputs_ReturnsFalse(string input)
     {
         var result = EnumParser.TryParseTicketStatus(input, out var status);
-        
+
         Assert.False(result);
     }
 
@@ -62,7 +62,7 @@ public class EnumParsingTests
     public void TryParseTicketPriority_ValidInputs_ReturnsCorrectPriority(string input, TicketPriority expected)
     {
         var result = EnumParser.TryParseTicketPriority(input, out var priority);
-        
+
         Assert.True(result);
         Assert.Equal(expected, priority);
     }
@@ -76,7 +76,7 @@ public class EnumParsingTests
     public void TryParseTicketPriority_InvalidInputs_ReturnsFalse(string input)
     {
         var result = EnumParser.TryParseTicketPriority(input, out var priority);
-        
+
         Assert.False(result);
     }
 }


### PR DESCRIPTION
## Summary
- Improved status/priority filter parsing to accept flexible input formats
- Enhanced user feedback for invalid filter values
- Clarified ticket list column headers

## Changes
1. **Flexible filter parsing**: The CLI now accepts various formats for status and priority values:
   - Case-insensitive matching (e.g., "Open", "open", "OPEN")
   - Numeric values (e.g., "2" for Open, "3" for Pending)
   - Common variations (e.g., "waiting on customer", "waiting-on-customer")

2. **Better error messages**: When users provide invalid status/priority values, they now receive clear error messages showing exactly which values are accepted.

3. **Clearer column headers**: Changed "Customer" column to "Requester Email" in ticket list to clarify what data is being displayed.

4. **Test coverage**: Added comprehensive unit tests for the new enum parsing functionality.

## Test Plan
- [x] Unit tests pass for enum parsing
- [x] Manual testing of various status formats
- [x] Error messages display correctly for invalid inputs
- [x] Ticket list displays with updated column header

## Example Usage
```bash
# All of these now work:
freshdesk ticket list --status Open
freshdesk ticket list --status open
freshdesk ticket list --status 2
freshdesk ticket list --status "waiting on customer"

# Invalid values show helpful error:
freshdesk ticket list --status InvalidStatus
# Output: Invalid status value: 'InvalidStatus'
#        Valid status values: Open, Pending, Resolved, Closed, WaitingOnCustomer, WaitingOnThirdParty
```