### PR TITLE
Add tab-completion support for bash, zsh, and PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,51 @@ export FRESHDESK_DOMAIN=yourcompany
 
 Configuration is stored at `~/.freshdesk/config.json` with secure file permissions (user-only on Unix systems).
 
+## Tab Completion
+
+The CLI supports tab completion for bash, zsh, and PowerShell. This feature dynamically generates completion scripts based on the current command structure, ensuring completions are always up-to-date.
+
+### Installation
+
+**Auto-detect and install for current shell:**
+```bash
+freshdesk install-completion
+```
+
+**Install for specific shell:**
+```bash
+freshdesk install-completion bash       # For Bash
+freshdesk install-completion zsh        # For Zsh  
+freshdesk install-completion powershell # For PowerShell
+```
+
+### Activation
+
+After installation, activate the completion:
+
+**Bash:**
+```bash
+source ~/.bashrc
+```
+
+**Zsh:**
+```bash
+source ~/.zshrc
+```
+
+**PowerShell:**
+```powershell
+. $PROFILE
+```
+
+### Features
+
+- Complete commands and subcommands (e.g., `freshdesk ti<TAB>` → `freshdesk ticket`)
+- Complete options and flags (e.g., `freshdesk ticket list --st<TAB>` → `freshdesk ticket list --status`)
+- Auto-complete enum values (e.g., `--status <TAB>` shows `open`, `pending`, `resolved`, `closed`)
+- File path completion for `--output` and `--file` options
+- Automatically stays in sync with command structure updates
+
 ## Usage
 
 ### Read-Only Mode

--- a/src/FreshdeskCLI/Helpers/CommandHelp.cs
+++ b/src/FreshdeskCLI/Helpers/CommandHelp.cs
@@ -4,7 +4,7 @@ namespace FreshdeskCLI.Helpers;
 
 public static class CommandHelp
 {
-    private static readonly Dictionary<string, CommandHelpInfo> HelpRegistry = new()
+    internal static readonly Dictionary<string, CommandHelpInfo> HelpRegistry = new()
     {
         ["config"] = new CommandHelpInfo
         {

--- a/src/FreshdeskCLI/Helpers/CompletionGenerator.cs
+++ b/src/FreshdeskCLI/Helpers/CompletionGenerator.cs
@@ -1,0 +1,306 @@
+using System.Text;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace FreshdeskCLI.Helpers;
+
+public static class CompletionGenerator
+{
+    private static readonly string[] GlobalOptions = ["--help", "-h", "--version", "-v", "--about", "--read-only", "-ro"];
+    private static readonly string[] StatusValues = ["open", "pending", "resolved", "closed"];
+    private static readonly string[] PriorityValues = ["low", "medium", "high", "urgent"];
+    private static readonly string[] FormatValues = ["json", "table", "csv"];
+    
+    private static string[] GetTopLevelCommands()
+    {
+        var topLevel = CommandHelp.HelpRegistry.Keys
+            .Where(k => !k.Contains(' '))
+            .ToArray();
+        return topLevel.Concat(["install-completion", "update", "bulk"]).ToArray();
+    }
+    
+    private static Dictionary<string, string[]> GetSubCommands()
+    {
+        var result = new Dictionary<string, string[]>();
+        
+        foreach (var kvp in CommandHelp.HelpRegistry)
+        {
+            if (!kvp.Key.Contains(' ') && kvp.Value.Subcommands != null)
+            {
+                result[kvp.Key] = kvp.Value.Subcommands.Keys.ToArray();
+            }
+        }
+        
+        result["install-completion"] = [];
+        result["update"] = [];
+        result["bulk"] = ["update", "export", "delete"];
+        return result;
+    }
+    
+    private static Dictionary<string, string[]> GetCommandOptions()
+    {
+        var result = new Dictionary<string, string[]>
+        {
+            ["global"] = GlobalOptions
+        };
+        
+        foreach (var kvp in CommandHelp.HelpRegistry)
+        {
+            if (kvp.Value.Options != null)
+            {
+                var options = new List<string>();
+                foreach (var opt in kvp.Value.Options.Keys)
+                {
+                    var parts = opt.Split(',').Select(p => p.Trim().Split(' ')[0]);
+                    options.AddRange(parts);
+                }
+                if (kvp.Value.RequiredOptions != null)
+                {
+                    foreach (var opt in kvp.Value.RequiredOptions.Keys)
+                    {
+                        var parts = opt.Split(',').Select(p => p.Trim().Split(' ')[0]);
+                        options.AddRange(parts);
+                    }
+                }
+                options.Add("--help");
+                options.Add("-h");
+                
+                var key = kvp.Key.Replace(" ", ".");
+                result[key] = options.Distinct().ToArray();
+            }
+        }
+        
+        result["bulk.update"] = ["--ids", "--status", "--priority", "--assignee", "--help", "-h"];
+        result["bulk.export"] = ["--ids", "--output", "--format", "--help", "-h"];
+        result["bulk.delete"] = ["--ids", "--confirm", "--help", "-h"];
+        
+        return result;
+    }
+
+    public static string GenerateBashCompletion()
+    {
+        var topLevelCommands = GetTopLevelCommands();
+        var subCommands = GetSubCommands();
+        var commandOptions = GetCommandOptions();
+        
+        var sb = new StringBuilder();
+        
+        sb.AppendLine("#!/bin/bash");
+        sb.AppendLine("# Bash completion script for freshdesk CLI");
+        sb.AppendLine("# Generated automatically - do not edit manually");
+        sb.AppendLine();
+        sb.AppendLine("_freshdesk() {");
+        sb.AppendLine("    local cur prev");
+        sb.AppendLine("    COMPREPLY=()");
+        sb.AppendLine("    cur=\"${COMP_WORDS[COMP_CWORD]}\"");
+        sb.AppendLine("    prev=\"${COMP_WORDS[COMP_CWORD-1]}\"");
+        sb.AppendLine();
+        
+        sb.AppendLine("    # Handle option value completion");
+        sb.AppendLine("    case \"${prev}\" in");
+        sb.AppendLine("        --status)");
+        sb.AppendLine($"            COMPREPLY=( $(compgen -W \"{string.Join(" ", StatusValues)}\" -- \"${{cur}}\") )");
+        sb.AppendLine("            return 0");
+        sb.AppendLine("            ;;");
+        sb.AppendLine("        --priority)");
+        sb.AppendLine($"            COMPREPLY=( $(compgen -W \"{string.Join(" ", PriorityValues)}\" -- \"${{cur}}\") )");
+        sb.AppendLine("            return 0");
+        sb.AppendLine("            ;;");
+        sb.AppendLine("        --format)");
+        sb.AppendLine($"            COMPREPLY=( $(compgen -W \"{string.Join(" ", FormatValues)}\" -- \"${{cur}}\") )");
+        sb.AppendLine("            return 0");
+        sb.AppendLine("            ;;");
+        sb.AppendLine("        --file|--output|-o)");
+        sb.AppendLine("            COMPREPLY=( $(compgen -f -- \"${cur}\") )");
+        sb.AppendLine("            return 0");
+        sb.AppendLine("            ;;");
+        sb.AppendLine("    esac");
+        sb.AppendLine();
+        
+        sb.AppendLine("    # Command position detection");
+        sb.AppendLine("    local cmd subcmd");
+        sb.AppendLine("    if [ $COMP_CWORD -ge 1 ]; then");
+        sb.AppendLine("        cmd=\"${COMP_WORDS[1]}\"");
+        sb.AppendLine("    fi");
+        sb.AppendLine("    if [ $COMP_CWORD -ge 2 ]; then");
+        sb.AppendLine("        subcmd=\"${COMP_WORDS[2]}\"");
+        sb.AppendLine("    fi");
+        sb.AppendLine();
+        
+        sb.AppendLine("    # First level: freshdesk [command]");
+        sb.AppendLine("    if [ $COMP_CWORD -eq 1 ]; then");
+        sb.AppendLine($"        COMPREPLY=( $(compgen -W \"{string.Join(" ", topLevelCommands.Concat(commandOptions["global"]))}\" -- \"${{cur}}\") )");
+        sb.AppendLine("        return 0");
+        sb.AppendLine("    fi");
+        sb.AppendLine();
+        
+        sb.AppendLine("    # Second level: freshdesk [command] [subcommand]");
+        sb.AppendLine("    if [ $COMP_CWORD -eq 2 ]; then");
+        sb.AppendLine("        case \"${cmd}\" in");
+        foreach (var kvp in subCommands)
+        {
+            if (kvp.Value.Length > 0)
+            {
+                sb.AppendLine($"            {kvp.Key})");
+                sb.AppendLine($"                COMPREPLY=( $(compgen -W \"{string.Join(" ", kvp.Value)}\" -- \"${{cur}}\") )");
+                sb.AppendLine("                return 0");
+                sb.AppendLine("                ;;");
+            }
+        }
+        sb.AppendLine("        esac");
+        sb.AppendLine("    fi");
+        sb.AppendLine();
+        
+        sb.AppendLine("    # Third level and beyond: options for specific commands");
+        sb.AppendLine("    if [ $COMP_CWORD -ge 3 ]; then");
+        sb.AppendLine("        local cmd_key=\"${cmd}.${subcmd}\"");
+        sb.AppendLine("        case \"${cmd_key}\" in");
+        foreach (var kvp in commandOptions.Where(k => k.Key.Contains('.')))
+        {
+            sb.AppendLine($"            {kvp.Key})");
+            sb.AppendLine($"                COMPREPLY=( $(compgen -W \"{string.Join(" ", kvp.Value)}\" -- \"${{cur}}\") )");
+            sb.AppendLine("                return 0");
+            sb.AppendLine("                ;;");
+        }
+        sb.AppendLine("        esac");
+        sb.AppendLine("    fi");
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine("complete -F _freshdesk freshdesk");
+        
+        return sb.ToString();
+    }
+
+    public static string GenerateZshCompletion()
+    {
+        var topLevelCommands = GetTopLevelCommands();
+        var subCommands = GetSubCommands();
+        
+        var sb = new StringBuilder();
+        
+        sb.AppendLine("#compdef freshdesk");
+        sb.AppendLine("# Zsh completion script for freshdesk CLI");
+        sb.AppendLine("# Generated automatically - do not edit manually");
+        sb.AppendLine();
+        sb.AppendLine("_freshdesk() {");
+        sb.AppendLine("    local line state");
+        sb.AppendLine();
+        sb.AppendLine("    _arguments -C \\");
+        sb.AppendLine("        '1: :_freshdesk_commands' \\");
+        sb.AppendLine("        '*::arg:->args'");
+        sb.AppendLine();
+        sb.AppendLine("    case $line[1] in");
+        foreach (var kvp in subCommands)
+        {
+            sb.AppendLine($"        {kvp.Key})");
+            sb.AppendLine($"            _freshdesk_{kvp.Key}");
+            sb.AppendLine("            ;;");
+        }
+        sb.AppendLine("    esac");
+        sb.AppendLine("}");
+        sb.AppendLine();
+        
+        sb.AppendLine("_freshdesk_commands() {");
+        sb.AppendLine("    local commands; commands=(");
+        foreach (var cmd in topLevelCommands)
+        {
+            sb.AppendLine($"        '{cmd}:Manage {cmd}'");
+        }
+        sb.AppendLine("    )");
+        sb.AppendLine("    _describe -t commands 'freshdesk command' commands");
+        sb.AppendLine("}");
+        sb.AppendLine();
+        
+        foreach (var kvp in subCommands.Where(k => k.Value.Length > 0))
+        {
+            sb.AppendLine($"_freshdesk_{kvp.Key}() {{");
+            sb.AppendLine("    local commands; commands=(");
+            foreach (var subcmd in kvp.Value)
+            {
+                sb.AppendLine($"        '{subcmd}:{GetSubcommandDescription(kvp.Key, subcmd)}'");
+            }
+            sb.AppendLine("    )");
+            sb.AppendLine($"    _describe -t commands 'freshdesk {kvp.Key} command' commands");
+            sb.AppendLine("}");
+            sb.AppendLine();
+        }
+        
+        sb.AppendLine("_freshdesk \"$@\"");
+        
+        return sb.ToString();
+    }
+    
+    public static string GeneratePowerShellCompletion()
+    {
+        var topLevelCommands = GetTopLevelCommands();
+        var subCommands = GetSubCommands();
+        
+        var sb = new StringBuilder();
+        
+        sb.AppendLine("# PowerShell completion script for freshdesk CLI");
+        sb.AppendLine("# Generated automatically - do not edit manually");
+        sb.AppendLine();
+        sb.AppendLine("Register-ArgumentCompleter -Native -CommandName freshdesk -ScriptBlock {");
+        sb.AppendLine("    param($wordToComplete, $commandAst, $cursorPosition)");
+        sb.AppendLine();
+        sb.AppendLine("    $commands = @{");
+        
+        foreach (var cmd in topLevelCommands)
+        {
+            sb.AppendLine($"        '{cmd}' = @{{");
+            if (subCommands.ContainsKey(cmd) && subCommands[cmd].Length > 0)
+            {
+                sb.AppendLine($"            'subcommands' = @({string.Join(", ", subCommands[cmd].Select(s => $"'{s}'"))})");
+            }
+            sb.AppendLine("        }");
+        }
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        
+        sb.AppendLine("    $completions = @()");
+        sb.AppendLine("    $elements = $commandAst.CommandElements");
+        sb.AppendLine("    $elementCount = $elements.Count");
+        sb.AppendLine();
+        sb.AppendLine("    if ($elementCount -eq 2) {");
+        sb.AppendLine("        # Complete top-level commands");
+        sb.AppendLine("        $completions = $commands.Keys | Where-Object { $_ -like \"$wordToComplete*\" }");
+        sb.AppendLine("    }");
+        sb.AppendLine("    elseif ($elementCount -eq 3) {");
+        sb.AppendLine("        # Complete subcommands");
+        sb.AppendLine("        $command = $elements[1].ToString()");
+        sb.AppendLine("        if ($commands.ContainsKey($command) -and $commands[$command].ContainsKey('subcommands')) {");
+        sb.AppendLine("            $completions = $commands[$command]['subcommands'] | Where-Object { $_ -like \"$wordToComplete*\" }");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine("    else {");
+        sb.AppendLine("        # Complete options");
+        sb.AppendLine("        $completions = @('--help', '--version', '--format', '--status', '--priority') | Where-Object { $_ -like \"$wordToComplete*\" }");
+        sb.AppendLine("    }");
+        sb.AppendLine();
+        sb.AppendLine("    $completions | ForEach-Object {");
+        sb.AppendLine("        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        
+        return sb.ToString();
+    }
+    
+    private static string GetSubcommandDescription(string command, string subcommand)
+    {
+        if (CommandHelp.HelpRegistry.TryGetValue(command, out var cmdHelp) && cmdHelp.Subcommands != null)
+        {
+            if (cmdHelp.Subcommands.TryGetValue(subcommand, out var desc))
+            {
+                return desc;
+            }
+        }
+        
+        return (command, subcommand) switch
+        {
+            ("bulk", "update") => "Update multiple tickets",
+            ("bulk", "export") => "Export multiple tickets",
+            ("bulk", "delete") => "Delete multiple tickets",
+            _ => $"{subcommand} operation"
+        };
+    }
+}

--- a/src/FreshdeskCLI/Helpers/CompletionGenerator.cs
+++ b/src/FreshdeskCLI/Helpers/CompletionGenerator.cs
@@ -10,7 +10,7 @@ public static class CompletionGenerator
     private static readonly string[] StatusValues = ["open", "pending", "resolved", "closed"];
     private static readonly string[] PriorityValues = ["low", "medium", "high", "urgent"];
     private static readonly string[] FormatValues = ["json", "table", "csv"];
-    
+
     private static string[] GetTopLevelCommands()
     {
         var topLevel = CommandHelp.HelpRegistry.Keys
@@ -18,11 +18,11 @@ public static class CompletionGenerator
             .ToArray();
         return topLevel.Concat(["install-completion", "update", "bulk"]).ToArray();
     }
-    
+
     private static Dictionary<string, string[]> GetSubCommands()
     {
         var result = new Dictionary<string, string[]>();
-        
+
         foreach (var kvp in CommandHelp.HelpRegistry)
         {
             if (!kvp.Key.Contains(' ') && kvp.Value.Subcommands != null)
@@ -30,20 +30,20 @@ public static class CompletionGenerator
                 result[kvp.Key] = kvp.Value.Subcommands.Keys.ToArray();
             }
         }
-        
+
         result["install-completion"] = [];
         result["update"] = [];
         result["bulk"] = ["update", "export", "delete"];
         return result;
     }
-    
+
     private static Dictionary<string, string[]> GetCommandOptions()
     {
         var result = new Dictionary<string, string[]>
         {
             ["global"] = GlobalOptions
         };
-        
+
         foreach (var kvp in CommandHelp.HelpRegistry)
         {
             if (kvp.Value.Options != null)
@@ -64,16 +64,16 @@ public static class CompletionGenerator
                 }
                 options.Add("--help");
                 options.Add("-h");
-                
+
                 var key = kvp.Key.Replace(" ", ".");
                 result[key] = options.Distinct().ToArray();
             }
         }
-        
+
         result["bulk.update"] = ["--ids", "--status", "--priority", "--assignee", "--help", "-h"];
         result["bulk.export"] = ["--ids", "--output", "--format", "--help", "-h"];
         result["bulk.delete"] = ["--ids", "--confirm", "--help", "-h"];
-        
+
         return result;
     }
 
@@ -82,9 +82,9 @@ public static class CompletionGenerator
         var topLevelCommands = GetTopLevelCommands();
         var subCommands = GetSubCommands();
         var commandOptions = GetCommandOptions();
-        
+
         var sb = new StringBuilder();
-        
+
         sb.AppendLine("#!/bin/bash");
         sb.AppendLine("# Bash completion script for freshdesk CLI");
         sb.AppendLine("# Generated automatically - do not edit manually");
@@ -95,7 +95,7 @@ public static class CompletionGenerator
         sb.AppendLine("    cur=\"${COMP_WORDS[COMP_CWORD]}\"");
         sb.AppendLine("    prev=\"${COMP_WORDS[COMP_CWORD-1]}\"");
         sb.AppendLine();
-        
+
         sb.AppendLine("    # Handle option value completion");
         sb.AppendLine("    case \"${prev}\" in");
         sb.AppendLine("        --status)");
@@ -116,7 +116,7 @@ public static class CompletionGenerator
         sb.AppendLine("            ;;");
         sb.AppendLine("    esac");
         sb.AppendLine();
-        
+
         sb.AppendLine("    # Command position detection");
         sb.AppendLine("    local cmd subcmd");
         sb.AppendLine("    if [ $COMP_CWORD -ge 1 ]; then");
@@ -126,14 +126,14 @@ public static class CompletionGenerator
         sb.AppendLine("        subcmd=\"${COMP_WORDS[2]}\"");
         sb.AppendLine("    fi");
         sb.AppendLine();
-        
+
         sb.AppendLine("    # First level: freshdesk [command]");
         sb.AppendLine("    if [ $COMP_CWORD -eq 1 ]; then");
         sb.AppendLine($"        COMPREPLY=( $(compgen -W \"{string.Join(" ", topLevelCommands.Concat(commandOptions["global"]))}\" -- \"${{cur}}\") )");
         sb.AppendLine("        return 0");
         sb.AppendLine("    fi");
         sb.AppendLine();
-        
+
         sb.AppendLine("    # Second level: freshdesk [command] [subcommand]");
         sb.AppendLine("    if [ $COMP_CWORD -eq 2 ]; then");
         sb.AppendLine("        case \"${cmd}\" in");
@@ -150,7 +150,7 @@ public static class CompletionGenerator
         sb.AppendLine("        esac");
         sb.AppendLine("    fi");
         sb.AppendLine();
-        
+
         sb.AppendLine("    # Third level and beyond: options for specific commands");
         sb.AppendLine("    if [ $COMP_CWORD -ge 3 ]; then");
         sb.AppendLine("        local cmd_key=\"${cmd}.${subcmd}\"");
@@ -167,7 +167,7 @@ public static class CompletionGenerator
         sb.AppendLine("}");
         sb.AppendLine();
         sb.AppendLine("complete -F _freshdesk freshdesk");
-        
+
         return sb.ToString();
     }
 
@@ -175,9 +175,9 @@ public static class CompletionGenerator
     {
         var topLevelCommands = GetTopLevelCommands();
         var subCommands = GetSubCommands();
-        
+
         var sb = new StringBuilder();
-        
+
         sb.AppendLine("#compdef freshdesk");
         sb.AppendLine("# Zsh completion script for freshdesk CLI");
         sb.AppendLine("# Generated automatically - do not edit manually");
@@ -199,7 +199,7 @@ public static class CompletionGenerator
         sb.AppendLine("    esac");
         sb.AppendLine("}");
         sb.AppendLine();
-        
+
         sb.AppendLine("_freshdesk_commands() {");
         sb.AppendLine("    local commands; commands=(");
         foreach (var cmd in topLevelCommands)
@@ -210,7 +210,7 @@ public static class CompletionGenerator
         sb.AppendLine("    _describe -t commands 'freshdesk command' commands");
         sb.AppendLine("}");
         sb.AppendLine();
-        
+
         foreach (var kvp in subCommands.Where(k => k.Value.Length > 0))
         {
             sb.AppendLine($"_freshdesk_{kvp.Key}() {{");
@@ -224,19 +224,19 @@ public static class CompletionGenerator
             sb.AppendLine("}");
             sb.AppendLine();
         }
-        
+
         sb.AppendLine("_freshdesk \"$@\"");
-        
+
         return sb.ToString();
     }
-    
+
     public static string GeneratePowerShellCompletion()
     {
         var topLevelCommands = GetTopLevelCommands();
         var subCommands = GetSubCommands();
-        
+
         var sb = new StringBuilder();
-        
+
         sb.AppendLine("# PowerShell completion script for freshdesk CLI");
         sb.AppendLine("# Generated automatically - do not edit manually");
         sb.AppendLine();
@@ -244,7 +244,7 @@ public static class CompletionGenerator
         sb.AppendLine("    param($wordToComplete, $commandAst, $cursorPosition)");
         sb.AppendLine();
         sb.AppendLine("    $commands = @{");
-        
+
         foreach (var cmd in topLevelCommands)
         {
             sb.AppendLine($"        '{cmd}' = @{{");
@@ -256,7 +256,7 @@ public static class CompletionGenerator
         }
         sb.AppendLine("    }");
         sb.AppendLine();
-        
+
         sb.AppendLine("    $completions = @()");
         sb.AppendLine("    $elements = $commandAst.CommandElements");
         sb.AppendLine("    $elementCount = $elements.Count");
@@ -281,10 +281,10 @@ public static class CompletionGenerator
         sb.AppendLine("        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)");
         sb.AppendLine("    }");
         sb.AppendLine("}");
-        
+
         return sb.ToString();
     }
-    
+
     private static string GetSubcommandDescription(string command, string subcommand)
     {
         if (CommandHelp.HelpRegistry.TryGetValue(command, out var cmdHelp) && cmdHelp.Subcommands != null)
@@ -294,7 +294,7 @@ public static class CompletionGenerator
                 return desc;
             }
         }
-        
+
         return (command, subcommand) switch
         {
             ("bulk", "update") => "Update multiple tickets",

--- a/src/FreshdeskCLI/Program.cs
+++ b/src/FreshdeskCLI/Program.cs
@@ -5,6 +5,7 @@ using FreshdeskCLI.Models;
 using FreshdeskCLI.Helpers;
 using FreshdeskCLI.Services;
 using static FreshdeskCLI.Helpers.EnumParser;
+using static FreshdeskCLI.Helpers.CompletionGenerator;
 
 // For now, use a simpler approach without System.CommandLine's complex features
 // System.CommandLine is AOT-compatible but the beta API is still evolving
@@ -149,6 +150,7 @@ static void ShowHelp(string? versionInfo = null)
     Console.WriteLine("  export tickets    Export tickets to file");
     Console.WriteLine("  export ticket     Export single ticket");
     Console.WriteLine("  update            Check for and install updates");
+    Console.WriteLine("  install-completion Install shell completion scripts");
     Console.WriteLine();
     Console.WriteLine("Options:");
     Console.WriteLine("  --version, -v      Show version information");
@@ -172,6 +174,7 @@ static async Task<int> RouteCommand(string[] args, bool isReadOnly = false)
         "attachment" => await HandleAttachmentCommand(args[1..], isReadOnly),
         "export" => await HandleExportCommand(args[1..]),
         "update" => await HandleUpdateCommand(args[1..]),
+        "install-completion" => await HandleInstallCompletionCommand(args[1..]),
         _ => ShowUnknownCommand(args[0])
     };
 }
@@ -1666,4 +1669,195 @@ static async Task<UpdateInfo?> CheckForUpdateInBackground(string currentVersion)
         // Silently ignore errors in background update check
         return null;
     }
+}
+
+static async Task<int> HandleInstallCompletionCommand(string[] args)
+{
+    if (CommandHelp.CheckForHelp(args))
+    {
+        Console.WriteLine("Usage: freshdesk install-completion [shell]");
+        Console.WriteLine();
+        Console.WriteLine("Install shell completion scripts for tab-completion support.");
+        Console.WriteLine();
+        Console.WriteLine("Supported shells:");
+        Console.WriteLine("  bash       - Bash shell (Linux/macOS)");
+        Console.WriteLine("  zsh        - Z shell (Linux/macOS)");
+        Console.WriteLine("  powershell - PowerShell (Windows/Linux/macOS)");
+        Console.WriteLine();
+        Console.WriteLine("Examples:");
+        Console.WriteLine("  freshdesk install-completion bash");
+        Console.WriteLine("  freshdesk install-completion zsh");
+        Console.WriteLine("  freshdesk install-completion powershell");
+        Console.WriteLine();
+        Console.WriteLine("After installation, restart your shell or source the profile:");
+        Console.WriteLine("  Bash:       source ~/.bashrc");
+        Console.WriteLine("  Zsh:        source ~/.zshrc");
+        Console.WriteLine("  PowerShell: . $PROFILE");
+        return 0;
+    }
+
+    string? shell = null;
+    if (args.Length > 0)
+    {
+        shell = args[0].ToLowerInvariant();
+    }
+    else
+    {
+        shell = DetectCurrentShell();
+        if (shell == null)
+        {
+            Console.WriteLine("Could not detect shell. Please specify: bash, zsh, or powershell");
+            return 1;
+        }
+        Console.WriteLine($"Detected shell: {shell}");
+    }
+
+    try
+    {
+        switch (shell)
+        {
+            case "bash":
+                return await InstallBashCompletion();
+            case "zsh":
+                return await InstallZshCompletion();
+            case "powershell":
+            case "pwsh":
+                return await InstallPowerShellCompletion();
+            default:
+                Console.Error.WriteLine($"Unsupported shell: {shell}");
+                Console.Error.WriteLine("Supported shells: bash, zsh, powershell");
+                return 1;
+        }
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"Failed to install completion: {ex.Message}");
+        return 1;
+    }
+}
+
+static string? DetectCurrentShell()
+{
+    var shellEnv = Environment.GetEnvironmentVariable("SHELL");
+    if (!string.IsNullOrEmpty(shellEnv))
+    {
+        if (shellEnv.Contains("bash"))
+            return "bash";
+        if (shellEnv.Contains("zsh"))
+            return "zsh";
+    }
+
+    var psModulePath = Environment.GetEnvironmentVariable("PSModulePath");
+    if (!string.IsNullOrEmpty(psModulePath))
+        return "powershell";
+
+    return null;
+}
+
+static async Task<int> InstallBashCompletion()
+{
+    var completion = CompletionGenerator.GenerateBashCompletion();
+    var homeDir = Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    
+    var completionsDir = Path.Combine(homeDir, ".local", "share", "bash-completion", "completions");
+    Directory.CreateDirectory(completionsDir);
+    
+    var completionFile = Path.Combine(completionsDir, "freshdesk");
+    await File.WriteAllTextAsync(completionFile, completion);
+    
+    var bashrcFile = Path.Combine(homeDir, ".bashrc");
+    if (File.Exists(bashrcFile))
+    {
+        var bashrcContent = await File.ReadAllTextAsync(bashrcFile);
+        var sourceCommand = $"[ -f {completionFile} ] && source {completionFile}";
+        
+        if (!bashrcContent.Contains(sourceCommand))
+        {
+            await File.AppendAllTextAsync(bashrcFile, $"\n# Freshdesk CLI completion\n{sourceCommand}\n");
+        }
+    }
+    
+    Console.WriteLine($"✓ Bash completion installed to {completionFile}");
+    Console.WriteLine("  Run 'source ~/.bashrc' to enable completion in current session");
+    return 0;
+}
+
+static async Task<int> InstallZshCompletion()
+{
+    var completion = CompletionGenerator.GenerateZshCompletion();
+    var homeDir = Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+    
+    var completionsDir = Path.Combine(homeDir, ".local", "share", "zsh", "site-functions");
+    Directory.CreateDirectory(completionsDir);
+    
+    var completionFile = Path.Combine(completionsDir, "_freshdesk");
+    await File.WriteAllTextAsync(completionFile, completion);
+    
+    var zshrcFile = Path.Combine(homeDir, ".zshrc");
+    if (File.Exists(zshrcFile))
+    {
+        var zshrcContent = await File.ReadAllTextAsync(zshrcFile);
+        var fpathCommand = $"fpath=({completionsDir} $fpath)";
+        
+        if (!zshrcContent.Contains(fpathCommand))
+        {
+            await File.AppendAllTextAsync(zshrcFile, $"\n# Freshdesk CLI completion\n{fpathCommand}\nautoload -Uz compinit && compinit\n");
+        }
+    }
+    
+    Console.WriteLine($"✓ Zsh completion installed to {completionFile}");
+    Console.WriteLine("  Run 'source ~/.zshrc' to enable completion in current session");
+    return 0;
+}
+
+static async Task<int> InstallPowerShellCompletion()
+{
+    var completion = CompletionGenerator.GeneratePowerShellCompletion();
+    
+    string? profilePath = null;
+    if (OperatingSystem.IsWindows())
+    {
+        var documentsPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        profilePath = Path.Combine(documentsPath, "PowerShell", "Microsoft.PowerShell_profile.ps1");
+    }
+    else
+    {
+        var homeDir = Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        profilePath = Path.Combine(homeDir, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
+    }
+    
+    if (profilePath != null)
+    {
+        var profileDir = Path.GetDirectoryName(profilePath);
+        if (profileDir != null)
+            Directory.CreateDirectory(profileDir);
+        
+        var completionFile = Path.Combine(Path.GetDirectoryName(profilePath)!, "freshdesk-completion.ps1");
+        await File.WriteAllTextAsync(completionFile, completion);
+        
+        if (!File.Exists(profilePath))
+        {
+            await File.WriteAllTextAsync(profilePath, $"# Freshdesk CLI completion\n. '{completionFile}'\n");
+        }
+        else
+        {
+            var profileContent = await File.ReadAllTextAsync(profilePath);
+            var sourceCommand = $". '{completionFile}'";
+            
+            if (!profileContent.Contains("freshdesk-completion.ps1"))
+            {
+                await File.AppendAllTextAsync(profilePath, $"\n# Freshdesk CLI completion\n{sourceCommand}\n");
+            }
+        }
+        
+        Console.WriteLine($"✓ PowerShell completion installed to {completionFile}");
+        Console.WriteLine($"  Run '. $PROFILE' to enable completion in current session");
+    }
+    else
+    {
+        Console.WriteLine("Could not determine PowerShell profile path");
+        return 1;
+    }
+    
+    return 0;
 }

--- a/src/FreshdeskCLI/Program.cs
+++ b/src/FreshdeskCLI/Program.cs
@@ -1758,25 +1758,25 @@ static async Task<int> InstallBashCompletion()
 {
     var completion = CompletionGenerator.GenerateBashCompletion();
     var homeDir = Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-    
+
     var completionsDir = Path.Combine(homeDir, ".local", "share", "bash-completion", "completions");
     Directory.CreateDirectory(completionsDir);
-    
+
     var completionFile = Path.Combine(completionsDir, "freshdesk");
     await File.WriteAllTextAsync(completionFile, completion);
-    
+
     var bashrcFile = Path.Combine(homeDir, ".bashrc");
     if (File.Exists(bashrcFile))
     {
         var bashrcContent = await File.ReadAllTextAsync(bashrcFile);
         var sourceCommand = $"[ -f {completionFile} ] && source {completionFile}";
-        
+
         if (!bashrcContent.Contains(sourceCommand))
         {
             await File.AppendAllTextAsync(bashrcFile, $"\n# Freshdesk CLI completion\n{sourceCommand}\n");
         }
     }
-    
+
     Console.WriteLine($"✓ Bash completion installed to {completionFile}");
     Console.WriteLine("  Run 'source ~/.bashrc' to enable completion in current session");
     return 0;
@@ -1786,25 +1786,25 @@ static async Task<int> InstallZshCompletion()
 {
     var completion = CompletionGenerator.GenerateZshCompletion();
     var homeDir = Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-    
+
     var completionsDir = Path.Combine(homeDir, ".local", "share", "zsh", "site-functions");
     Directory.CreateDirectory(completionsDir);
-    
+
     var completionFile = Path.Combine(completionsDir, "_freshdesk");
     await File.WriteAllTextAsync(completionFile, completion);
-    
+
     var zshrcFile = Path.Combine(homeDir, ".zshrc");
     if (File.Exists(zshrcFile))
     {
         var zshrcContent = await File.ReadAllTextAsync(zshrcFile);
         var fpathCommand = $"fpath=({completionsDir} $fpath)";
-        
+
         if (!zshrcContent.Contains(fpathCommand))
         {
             await File.AppendAllTextAsync(zshrcFile, $"\n# Freshdesk CLI completion\n{fpathCommand}\nautoload -Uz compinit && compinit\n");
         }
     }
-    
+
     Console.WriteLine($"✓ Zsh completion installed to {completionFile}");
     Console.WriteLine("  Run 'source ~/.zshrc' to enable completion in current session");
     return 0;
@@ -1813,7 +1813,7 @@ static async Task<int> InstallZshCompletion()
 static async Task<int> InstallPowerShellCompletion()
 {
     var completion = CompletionGenerator.GeneratePowerShellCompletion();
-    
+
     string? profilePath = null;
     if (OperatingSystem.IsWindows())
     {
@@ -1825,16 +1825,16 @@ static async Task<int> InstallPowerShellCompletion()
         var homeDir = Environment.GetEnvironmentVariable("HOME") ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         profilePath = Path.Combine(homeDir, ".config", "powershell", "Microsoft.PowerShell_profile.ps1");
     }
-    
+
     if (profilePath != null)
     {
         var profileDir = Path.GetDirectoryName(profilePath);
         if (profileDir != null)
             Directory.CreateDirectory(profileDir);
-        
+
         var completionFile = Path.Combine(Path.GetDirectoryName(profilePath)!, "freshdesk-completion.ps1");
         await File.WriteAllTextAsync(completionFile, completion);
-        
+
         if (!File.Exists(profilePath))
         {
             await File.WriteAllTextAsync(profilePath, $"# Freshdesk CLI completion\n. '{completionFile}'\n");
@@ -1843,13 +1843,13 @@ static async Task<int> InstallPowerShellCompletion()
         {
             var profileContent = await File.ReadAllTextAsync(profilePath);
             var sourceCommand = $". '{completionFile}'";
-            
+
             if (!profileContent.Contains("freshdesk-completion.ps1"))
             {
                 await File.AppendAllTextAsync(profilePath, $"\n# Freshdesk CLI completion\n{sourceCommand}\n");
             }
         }
-        
+
         Console.WriteLine($"✓ PowerShell completion installed to {completionFile}");
         Console.WriteLine($"  Run '. $PROFILE' to enable completion in current session");
     }
@@ -1858,6 +1858,6 @@ static async Task<int> InstallPowerShellCompletion()
         Console.WriteLine("Could not determine PowerShell profile path");
         return 1;
     }
-    
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- Adds tab-completion support for bash, zsh, and PowerShell shells
- Implements dynamic completion generation that automatically stays in sync with command structure
- Provides easy installation via `freshdesk install-completion` command

## Features
- **Dynamic completion generation** - Completions are generated from the CommandHelp registry
- **Multi-shell support** - Works with bash, zsh, and PowerShell
- **Smart completions** - Supports commands, subcommands, options, and enum values
- **File path completion** - Automatic file completion for `--output` and `--file` options
- **Auto-detection** - Automatically detects current shell if not specified
- **AOT-compatible** - No reflection used, fully compatible with AOT compilation

## Implementation Details
The completion system leverages the existing `CommandHelp` registry as the single source of truth for command structure. This ensures that:
- New commands automatically appear in completions
- No duplicate maintenance is required
- The system stays synchronized as the CLI evolves

## Usage
```bash
# Auto-detect and install for current shell
freshdesk install-completion

# Install for specific shell
freshdesk install-completion bash
freshdesk install-completion zsh
freshdesk install-completion powershell
```

## Test Plan
- [x] Build passes with AOT compilation
- [x] Bash completion script generation tested
- [x] Installation command works correctly
- [ ] CI/CD pipeline passes
- [ ] Integration tests pass