### PR TITLE
Fix contact/company command bugs and add missing help text

### DIFF
--- a/src/FreshdeskCLI/Helpers/CommandHelp.cs
+++ b/src/FreshdeskCLI/Helpers/CommandHelp.cs
@@ -285,6 +285,239 @@ public static class CommandHelp
                 "freshdesk export ticket 123 --include-conversations --output ticket.json"
             }
         },
+        ["contact"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk contact <subcommand> [options]",
+            Description = "Manage Freshdesk contacts",
+            Subcommands = new Dictionary<string, string>
+            {
+                ["list"] = "List contacts",
+                ["get"] = "Get contact details",
+                ["create"] = "Create a new contact",
+                ["update"] = "Update an existing contact",
+                ["search"] = "Search contacts by email or phone",
+                ["delete"] = "Delete a contact"
+            }
+        },
+        ["contact list"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk contact list [options]",
+            Description = "List contacts with optional pagination",
+            Options = new Dictionary<string, string>
+            {
+                ["--page, -p <number>"] = "Page number (default: 1)",
+                ["--limit, -l <number>"] = "Items per page (default: 30)",
+                ["--format, -f <format>"] = "Output format (table, json, csv) (default: table)"
+            },
+            Examples = new[]
+            {
+                "freshdesk contact list",
+                "freshdesk contact list --page 2 --limit 50",
+                "freshdesk contact list --format json"
+            }
+        },
+        ["contact get"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk contact get <contact-id> [options]",
+            Description = "Get detailed information about a specific contact",
+            Options = new Dictionary<string, string>
+            {
+                ["--format, -f <format>"] = "Output format (table, json) (default: table)"
+            },
+            Examples = new[]
+            {
+                "freshdesk contact get 123",
+                "freshdesk contact get 123 --format json"
+            }
+        },
+        ["contact create"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk contact create [options]",
+            Description = "Create a new contact",
+            RequiredOptions = new Dictionary<string, string>
+            {
+                ["--name <name>"] = "Contact name",
+                ["--email <email>"] = "Contact email address"
+            },
+            Options = new Dictionary<string, string>
+            {
+                ["--phone <phone>"] = "Phone number",
+                ["--mobile <mobile>"] = "Mobile number",
+                ["--job-title <title>"] = "Job title",
+                ["--company-id, --company <id>"] = "Company ID to associate with",
+                ["--view-all-tickets"] = "Allow contact to view all company tickets (flag or true/false)",
+                ["--no-view-all-tickets"] = "Prevent contact from viewing all company tickets",
+                ["--description <desc>"] = "Contact description",
+                ["--address <address>"] = "Contact address",
+                ["--custom-field <key=value>"] = "Set a custom field (repeatable)"
+            },
+            Examples = new[]
+            {
+                "freshdesk contact create --name \"John Doe\" --email john@example.com",
+                "freshdesk contact create --name \"Jane\" --email jane@example.com --company 123 --view-all-tickets",
+                "freshdesk contact create --name \"Bob\" --email bob@example.com --job-title \"Engineer\" --phone \"+1234567890\""
+            }
+        },
+        ["contact update"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk contact update <contact-id> [options]",
+            Description = "Update an existing contact",
+            Options = new Dictionary<string, string>
+            {
+                ["--name <name>"] = "Contact name",
+                ["--email <email>"] = "Contact email address",
+                ["--phone <phone>"] = "Phone number",
+                ["--mobile <mobile>"] = "Mobile number",
+                ["--job-title <title>"] = "Job title",
+                ["--company-id, --company <id>"] = "Company ID to associate with",
+                ["--view-all-tickets"] = "Allow contact to view all company tickets (flag or true/false)",
+                ["--no-view-all-tickets"] = "Prevent contact from viewing all company tickets",
+                ["--description <desc>"] = "Contact description"
+            },
+            Examples = new[]
+            {
+                "freshdesk contact update 123 --name \"Jane Smith\"",
+                "freshdesk contact update 123 --company 456 --view-all-tickets",
+                "freshdesk contact update 123 --no-view-all-tickets"
+            }
+        },
+        ["contact search"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk contact search [options]",
+            Description = "Search for contacts by email or phone",
+            Options = new Dictionary<string, string>
+            {
+                ["--email <email>"] = "Search by email address",
+                ["--phone <phone>"] = "Search by phone number",
+                ["--format, -f <format>"] = "Output format (table, json, csv) (default: table)"
+            },
+            Examples = new[]
+            {
+                "freshdesk contact search --email john@example.com",
+                "freshdesk contact search --phone \"+1234567890\"",
+                "freshdesk contact search --email example.com --format json"
+            }
+        },
+        ["contact delete"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk contact delete <contact-id>",
+            Description = "Delete a contact",
+            Examples = new[]
+            {
+                "freshdesk contact delete 123"
+            }
+        },
+        ["company"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk company <subcommand> [options]",
+            Description = "Manage Freshdesk companies",
+            Subcommands = new Dictionary<string, string>
+            {
+                ["list"] = "List companies",
+                ["get"] = "Get company details",
+                ["create"] = "Create a new company",
+                ["update"] = "Update an existing company",
+                ["search"] = "Search companies by name",
+                ["delete"] = "Delete a company"
+            }
+        },
+        ["company list"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk company list [options]",
+            Description = "List companies with optional pagination",
+            Options = new Dictionary<string, string>
+            {
+                ["--page, -p <number>"] = "Page number (default: 1)",
+                ["--limit, -l <number>"] = "Items per page (default: 30)",
+                ["--format, -f <format>"] = "Output format (table, json, csv) (default: table)"
+            },
+            Examples = new[]
+            {
+                "freshdesk company list",
+                "freshdesk company list --page 2 --format json"
+            }
+        },
+        ["company get"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk company get <company-id> [options]",
+            Description = "Get detailed information about a specific company",
+            Options = new Dictionary<string, string>
+            {
+                ["--format, -f <format>"] = "Output format (table, json) (default: table)"
+            },
+            Examples = new[]
+            {
+                "freshdesk company get 123",
+                "freshdesk company get 123 --format json"
+            }
+        },
+        ["company create"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk company create [options]",
+            Description = "Create a new company",
+            RequiredOptions = new Dictionary<string, string>
+            {
+                ["--name <name>"] = "Company name"
+            },
+            Options = new Dictionary<string, string>
+            {
+                ["--description <desc>"] = "Company description",
+                ["--domains <domains>"] = "Comma-separated list of domains",
+                ["--industry <industry>"] = "Industry type",
+                ["--health-score <score>"] = "Health score",
+                ["--note <note>"] = "Company note",
+                ["--custom-field <key=value>"] = "Set a custom field (repeatable)"
+            },
+            Examples = new[]
+            {
+                "freshdesk company create --name \"Acme Corp\"",
+                "freshdesk company create --name \"Acme\" --domains \"acme.com,acme.org\" --industry \"Technology\""
+            }
+        },
+        ["company update"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk company update <company-id> [options]",
+            Description = "Update an existing company",
+            Options = new Dictionary<string, string>
+            {
+                ["--name <name>"] = "Company name",
+                ["--description <desc>"] = "Company description",
+                ["--domains <domains>"] = "Comma-separated list of domains",
+                ["--industry <industry>"] = "Industry type",
+                ["--health-score <score>"] = "Health score",
+                ["--note <note>"] = "Company note",
+                ["--custom-field <key=value>"] = "Set a custom field (repeatable)"
+            },
+            Examples = new[]
+            {
+                "freshdesk company update 123 --name \"Acme Corporation\"",
+                "freshdesk company update 123 --industry \"SaaS\" --health-score \"Happy\""
+            }
+        },
+        ["company search"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk company search [options]",
+            Description = "Search for companies by name",
+            Options = new Dictionary<string, string>
+            {
+                ["--name, -n <name>"] = "Company name to search for",
+                ["--format, -f <format>"] = "Output format (table, json, csv) (default: table)"
+            },
+            Examples = new[]
+            {
+                "freshdesk company search --name \"Acme\"",
+                "freshdesk company search --name \"Tech\" --format json"
+            }
+        },
+        ["company delete"] = new CommandHelpInfo
+        {
+            Usage = "freshdesk company delete <company-id>",
+            Description = "Delete a company",
+            Examples = new[]
+            {
+                "freshdesk company delete 123"
+            }
+        },
         ["update"] = new CommandHelpInfo
         {
             Usage = "freshdesk update [options]",

--- a/src/FreshdeskCLI/Helpers/OutputFormatter.cs
+++ b/src/FreshdeskCLI/Helpers/OutputFormatter.cs
@@ -300,7 +300,7 @@ public static class OutputFormatter
             Console.WriteLine($"Job Title: {contact.JobTitle}");
         if (contact.CompanyId.HasValue)
             Console.WriteLine($"Company ID: {contact.CompanyId.Value}");
-        Console.WriteLine($"View All Tickets: {contact.ViewAllTickets}");
+        Console.WriteLine($"View All Tickets: {contact.ViewAllTickets?.ToString() ?? "N/A"}");
         Console.WriteLine($"Active: {contact.Active}");
         Console.WriteLine($"Language: {contact.Language}");
         if (!string.IsNullOrEmpty(contact.TimeZone))

--- a/src/FreshdeskCLI/Models/Contact.cs
+++ b/src/FreshdeskCLI/Models/Contact.cs
@@ -16,7 +16,7 @@ public sealed class Contact
     public bool Active { get; set; }
     public string Language { get; set; } = "en";
     public string? TimeZone { get; set; }
-    public bool ViewAllTickets { get; set; }
+    public bool? ViewAllTickets { get; set; }
     public CompanyAssociation[]? OtherCompanies { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }

--- a/src/FreshdeskCLI/Program.cs
+++ b/src/FreshdeskCLI/Program.cs
@@ -807,14 +807,54 @@ static async Task<int> HandleTicketSearch(string[] args, FreshdeskCLI.Services.F
         return 1;
     }
 
-    var tickets = await client.GetTicketsAsync(1, 100, statusFilter, emailFilter);
+    Ticket[] tickets;
 
-    // Apply additional filters
+    // Use Freshdesk Search API for structured filters (status, priority)
+    var queryParts = new List<string>();
+    if (statusFilter.HasValue)
+        queryParts.Add($"status:{(int)statusFilter.Value}");
     if (priorityFilter.HasValue)
+        queryParts.Add($"priority:{(int)priorityFilter.Value}");
+
+    if (queryParts.Count > 0 || !string.IsNullOrEmpty(emailFilter))
     {
-        tickets = tickets.Where(t => t.Priority == priorityFilter.Value).ToArray();
+        // Search API doesn't support subject text search, so we use it
+        // for structured filters and apply text filter client-side
+        if (!string.IsNullOrEmpty(emailFilter))
+        {
+            tickets = await client.GetTicketsAsync(1, 100, statusFilter, emailFilter);
+            if (priorityFilter.HasValue)
+                tickets = tickets.Where(t => t.Priority == priorityFilter.Value).ToArray();
+        }
+        else
+        {
+            var searchQuery = string.Join(" AND ", queryParts);
+            var allResults = new List<Ticket>();
+            for (int page = 1; page <= 10; page++)
+            {
+                var pageResults = await client.SearchTicketsAsync(searchQuery, page);
+                if (pageResults.Length == 0) break;
+                allResults.AddRange(pageResults);
+                if (pageResults.Length < 30) break;
+            }
+            tickets = allResults.ToArray();
+        }
+    }
+    else
+    {
+        // Text-only search: paginate through list endpoint
+        var allTickets = new List<Ticket>();
+        for (int page = 1; page <= 10; page++)
+        {
+            var pageTickets = await client.GetTicketsAsync(page, 100);
+            if (pageTickets.Length == 0) break;
+            allTickets.AddRange(pageTickets);
+            if (pageTickets.Length < 100) break;
+        }
+        tickets = allTickets.ToArray();
     }
 
+    // Apply text query filter client-side (Search API doesn't support subject/description search)
     if (!string.IsNullOrEmpty(textQuery))
     {
         tickets = tickets.Where(t =>
@@ -2094,11 +2134,23 @@ static async Task<int> HandleContactCreate(string[] args, FreshdeskCLI.Services.
                 contactData["job_title"] = args[++i];
                 break;
             case "--company-id" when i + 1 < args.Length && long.TryParse(args[i + 1], out var cid):
+            case "--company" when i + 1 < args.Length && long.TryParse(args[i + 1], out cid):
                 contactData["company_id"] = cid;
                 i++;
                 break;
             case "--view-all-tickets":
-                contactData["view_all_tickets"] = true;
+                if (i + 1 < args.Length && bool.TryParse(args[i + 1], out var vatCreate))
+                {
+                    contactData["view_all_tickets"] = vatCreate;
+                    i++;
+                }
+                else
+                {
+                    contactData["view_all_tickets"] = true;
+                }
+                break;
+            case "--no-view-all-tickets":
+                contactData["view_all_tickets"] = false;
                 break;
             case "--description" when i + 1 < args.Length:
                 contactData["description"] = args[++i];
@@ -2167,11 +2219,23 @@ static async Task<int> HandleContactUpdate(string[] args, FreshdeskCLI.Services.
                 updates["job_title"] = args[++i];
                 break;
             case "--company-id" when i + 1 < args.Length && long.TryParse(args[i + 1], out var cid):
+            case "--company" when i + 1 < args.Length && long.TryParse(args[i + 1], out cid):
                 updates["company_id"] = cid;
                 i++;
                 break;
-            case "--view-all-tickets" when i + 1 < args.Length:
-                updates["view_all_tickets"] = bool.Parse(args[++i]);
+            case "--view-all-tickets":
+                if (i + 1 < args.Length && bool.TryParse(args[i + 1], out var vatUpdate))
+                {
+                    updates["view_all_tickets"] = vatUpdate;
+                    i++;
+                }
+                else
+                {
+                    updates["view_all_tickets"] = true;
+                }
+                break;
+            case "--no-view-all-tickets":
+                updates["view_all_tickets"] = false;
                 break;
             case "--description" when i + 1 < args.Length:
                 updates["description"] = args[++i];

--- a/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
+++ b/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
@@ -19,6 +19,8 @@ public interface IFreshdeskApiClient
     Task<byte[]> DownloadAttachmentByIdAsync(long attachmentId, CancellationToken cancellationToken = default);
     Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default);
 
+    Task<Ticket[]> SearchTicketsAsync(string query, int page = 1, CancellationToken cancellationToken = default);
+
     Task<Contact[]> GetContactsAsync(int page = 1, int limit = 30, CancellationToken cancellationToken = default);
     Task<Contact?> GetContactAsync(long id, CancellationToken cancellationToken = default);
     Task<Contact> CreateContactAsync(Dictionary<string, object> contactData, CancellationToken cancellationToken = default);
@@ -407,6 +409,19 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
             ".xml" => "application/xml",
             _ => "application/octet-stream"
         };
+    }
+
+    public async Task<Ticket[]> SearchTicketsAsync(string query, int page = 1, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+
+        var endpoint = $"/api/v2/search/tickets?query=\"{Uri.EscapeDataString(query)}\"&page={page}";
+        var response = await _httpClient.GetAsync(endpoint, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken);
+        var searchResult = JsonSerializer.Deserialize(json, FreshdeskJsonContext.Default.TicketSearchResult);
+        return searchResult?.Results ?? [];
     }
 
     public async Task<Contact[]> GetContactsAsync(int page = 1, int limit = 30, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

Fixes 6 open issues from the v1.3.0 contact/company management feature:

- **#90 / #94**: `Contact.ViewAllTickets` deserialization failure — changed from `bool` to `bool?` to handle null API responses. Display shows "N/A" for null values.
- **#93**: `--company` flag not recognized — added `--company` as alias for `--company-id` in both contact create and update.
- **#92**: Inconsistent `--view-all-tickets` between create/update — both now accept flag-only (sets true), explicit `true`/`false` value, and `--no-view-all-tickets` (sets false).
- **#91**: Missing help text — added `HelpRegistry` entries for all 12 contact and company subcommands.
- **#87**: `ticket search` only searched first 100 tickets — now uses Freshdesk Search API for structured filters (status, priority) and paginates through up to 1000 tickets for text queries.

Closes #87, closes #90, closes #91, closes #92, closes #93, closes #94

## Files Changed

| File | Changes |
|------|---------|
| `Models/Contact.cs` | `ViewAllTickets` → `bool?` |
| `Helpers/OutputFormatter.cs` | Handle nullable `ViewAllTickets` display |
| `Helpers/CommandHelp.cs` | Added 14 help entries (contact + company subcommands) |
| `Program.cs` | `--company` alias, consistent `--view-all-tickets`/`--no-view-all-tickets`, improved ticket search |
| `Services/FreshdeskApiClient.cs` | Added `SearchTicketsAsync` method |

## Test plan

- [x] `dotnet build -c Release` — compiles clean, 0 warnings
- [x] `dotnet test -c Release` — all 118 tests pass
- [x] `dotnet run -- --test-aot` — AOT serialization tests pass
- [x] Live validation: `contact list`, `contact get` (null + non-null ViewAllTickets), `contact search`, `company list`
- [x] Live validation: `ticket search "cluster"` (text), `ticket search --status open` (Search API), combined text + status
- [x] Help text: `contact --help`, `contact create --help`, `company --help`