### PR TITLE
Bump MicrosoftNetVersion from 9.0.12 to 9.0.13

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Nuget package versions -->
-    <MicrosoftNetVersion>9.0.12</MicrosoftNetVersion>
+    <MicrosoftNetVersion>9.0.13</MicrosoftNetVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Bumps all Microsoft.NET packages from 9.0.12 to 9.0.13

Fixes AOT compilation failure where ILCompiler 9.0.12 cannot handle the 9.0.13 runtime that the CI SDK rolls forward to. This also unblocks the 3 dependabot PRs (#62, #76, #77) that are waiting to merge.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings
- [x] `dotnet test -c Release` — 118 tests pass
- [ ] AOT compilation on CI (linux-x64, osx-arm64, win-x64)