### PR TITLE
Prepare release 1.3.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,61 +2,31 @@
 <Project>
   <PropertyGroup>
     <!-- Version configuration -->
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.3.1</VersionPrefix>
     <!-- Get Git commit hash at build time -->
     <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-    <PackageReleaseNotes>**Major Feature Release**
+    <PackageReleaseNotes>**Bug Fix Release**
 
-This release adds comprehensive contact and company management commands, enabling full programmatic control over Freshdesk contacts and organizations.
+This release fixes several bugs in the v1.3.0 contact and company management feature.
 
-**New Features:**
-- **Contact Management** (#88)
-  - Full CRUD operations: list, get, create, update, search, delete
-  - Set `view_all_tickets` flag to allow contacts to see all company tickets
-  - Search contacts by email or phone
-  - Associate contacts with companies
-  - Support for all contact fields (name, email, phone, mobile, job title, etc.)
-
-- **Company Management** (#88)
-  - Full CRUD operations: list, get, create, update, search, delete
-  - Search companies by name
-  - Manage company properties (domains, industry, health score, notes)
-  - Associate contacts with companies during creation
-
-- **Generic Custom Fields** (#88)
-  - Added `--custom-field` parameter for instance-specific required fields
-  - Works with both contacts and companies
-  - Supports multiple custom fields per command
-
-- **Enhanced Error Reporting** (#88)
-  - Display actual Freshdesk API error messages for better troubleshooting
-  - Clearer validation errors for missing required fields
+**Bug Fixes:**
+- **Fixed Contact Deserialization Failure** (#90, #94)
+  - `ViewAllTickets` now nullable to handle null API responses
+  - Displays "N/A" when the field is not set
+- **Fixed `--company` Flag** (#93)
+  - Added `--company` as alias for `--company-id` in contact create and update
+- **Fixed `--view-all-tickets` Inconsistency** (#92)
+  - Both create and update now accept flag-only, explicit true/false, and `--no-view-all-tickets`
+- **Fixed Ticket Search** (#87)
+  - Uses Freshdesk Search API for structured filters (status, priority)
+  - Paginates through up to 1000 tickets for text queries
+  - Previously only searched the first 100 tickets
+- **Added Missing Help Text** (#91)
+  - Added help entries for all contact and company subcommands
 
 **Technical Improvements:**
-- Fixed .NET version mismatch in AOT builds (updated to .NET 9.0.12)
-- Improved Dictionary-based write operations to exclude read-only fields
-- Enhanced output formatters for contact and company data
-- Full pagination support for list operations
-- Maintained AOT compatibility and performance standards
-
-**Usage Examples:**
-```bash
-# Create a company
-freshdesk company create --name "Acme Corp" --description "A great company"
-
-# Create a contact with view_all_tickets enabled
-freshdesk contact create --name "John Doe" --email john@acme.com \
-  --company-id 12345 --view-all-tickets
-
-# Search for contacts by email
-freshdesk contact search --email john@acme.com
-
-# List all companies
-freshdesk company list --format table
-```
-
-**Why This Matters:**
-The `view_all_tickets` flag solves intermittent unique value errors when managing contacts via the Freshdesk web UI. By creating contacts programmatically with this flag, you can ensure contacts have proper visibility across all company tickets.
+- Updated .NET packages from 9.0.12 to 9.0.13
+- Fixed AOT compilation failure with ILCompiler version mismatch
 
 **Installation:**
 Update using the self-update command:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,45 @@
+#### 1.3.1 February 11th 2026 ####
+
+**Bug Fix Release**
+
+This release fixes several bugs in the v1.3.0 contact and company management feature.
+
+**Bug Fixes:**
+- **Fixed Contact Deserialization Failure** (#90, #94)
+  - `ViewAllTickets` now nullable to handle null API responses
+  - Displays "N/A" when the field is not set
+- **Fixed `--company` Flag** (#93)
+  - Added `--company` as alias for `--company-id` in contact create and update
+- **Fixed `--view-all-tickets` Inconsistency** (#92)
+  - Both create and update now accept flag-only, explicit true/false, and `--no-view-all-tickets`
+- **Fixed Ticket Search** (#87)
+  - Uses Freshdesk Search API for structured filters (status, priority)
+  - Paginates through up to 1000 tickets for text queries
+  - Previously only searched the first 100 tickets
+- **Added Missing Help Text** (#91)
+  - Added help entries for all contact and company subcommands
+
+**Technical Improvements:**
+- Updated .NET packages from 9.0.12 to 9.0.13
+- Fixed AOT compilation failure with ILCompiler version mismatch
+
+**Installation:**
+Update using the self-update command:
+```bash
+freshdesk update
+```
+
+Or use the one-command installer:
+```bash
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash
+```
+
+**Platform Support:**
+- Linux x64
+- macOS x64 (Intel)
+- macOS ARM64 (Apple Silicon)
+- Windows x64
+
 #### 1.3.0 February 2nd 2026 ####
 
 **Major Feature Release**


### PR DESCRIPTION
## Summary

Patch release fixing 6 bugs in the v1.3.0 contact/company management feature.

**Bug Fixes:**
- #87 - `ticket search` now uses Freshdesk Search API + pagination (up to 1000 tickets)
- #90 / #94 - `Contact.ViewAllTickets` nullable to handle null API responses
- #91 - Added missing help text for all contact and company subcommands
- #92 - Consistent `--view-all-tickets` behavior between create and update
- #93 - Added `--company` as alias for `--company-id`

**Maintenance:**
- Bumped .NET packages from 9.0.12 to 9.0.13 (fixes AOT ILCompiler mismatch)

## Test plan

- [x] `dotnet build -c Release` — 0 warnings
- [x] `dotnet test -c Release` — 118 tests pass
- [x] `dotnet run -- --test-aot` — AOT serialization tests pass
- [x] Live validated against Freshdesk instance (read-only)
- [x] Version output shows `1.3.1`