### PR TITLE
fix: remove duplicate 'update' key from PowerShell completion script (#110)

### DIFF
--- a/src/FreshdeskCLI/Helpers/CompletionGenerator.cs
+++ b/src/FreshdeskCLI/Helpers/CompletionGenerator.cs
@@ -32,7 +32,6 @@ public static class CompletionGenerator
         }
 
         result["install-completion"] = [];
-        result["update"] = [];
         result["bulk"] = ["update", "export", "delete"];
         return result;
     }


### PR DESCRIPTION
## Summary

- `GetSubCommands()` was explicitly adding `result["update"] = []`, but `"update"` is already included in `GetTopLevelCommands()` via `.Concat(["install-completion", "update", "bulk"])`.
- When `GeneratePowerShellCompletion()` iterates over `topLevelCommands` to build the `$commands` hashtable, `'update'` ended up as a duplicate key, causing a `ParserError` when the script was loaded in PowerShell.
- Fix: remove the redundant `result["update"] = [];` line from `GetSubCommands()`.

## Test plan

- [ ] Build passes with no errors or warnings: `dotnet build src/FreshdeskCLI`
- [ ] Run `freshdesk install-completion --shell powershell` and verify the generated script loads in both PowerShell 5.1 and PowerShell 7 without a `ParserError`
- [ ] Confirm `'update'` appears exactly once in the generated `$commands` hashtable

Closes #110