### PR TITLE
Prepare release 1.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,31 +2,29 @@
 <Project>
   <PropertyGroup>
     <!-- Version configuration -->
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.4.0</VersionPrefix>
     <!-- Get Git commit hash at build time -->
     <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-    <PackageReleaseNotes>**Bug Fix Release**
+    <PackageReleaseNotes>**Feature and Bug Fix Release**
 
-This release fixes several bugs in the v1.3.0 contact and company management feature.
+This release adds company field discovery capabilities and fixes several PowerShell and company search issues.
+
+**New Features:**
+- **Company Fields Command** (#113)
+  - Added `company fields` command for discovering custom fields in your Freshdesk instance
+  - List all available company fields with their types and properties
+  - Essential for building automated company management workflows
 
 **Bug Fixes:**
-- **Fixed Contact Deserialization Failure** (#90, #94)
-  - `ViewAllTickets` now nullable to handle null API responses
-  - Displays "N/A" when the field is not set
-- **Fixed `--company` Flag** (#93)
-  - Added `--company` as alias for `--company-id` in contact create and update
-- **Fixed `--view-all-tickets` Inconsistency** (#92)
-  - Both create and update now accept flag-only, explicit true/false, and `--no-view-all-tickets`
-- **Fixed Ticket Search** (#87)
-  - Uses Freshdesk Search API for structured filters (status, priority)
-  - Paginates through up to 1000 tickets for text queries
-  - Previously only searched the first 100 tickets
-- **Added Missing Help Text** (#91)
-  - Added help entries for all contact and company subcommands
+- **Fixed PowerShell Completion Installation** (#110, #111)
+  - Removed duplicate 'update' key from PowerShell completion script
+  - Now installs to both PowerShell 5.1 and PowerShell 7 profile paths
+  - Improved compatibility across Windows PowerShell versions
 
-**Technical Improvements:**
-- Updated .NET packages from 9.0.12 to 9.0.13
-- Fixed AOT compilation failure with ILCompiler version mismatch
+- **Fixed Company Search JSON Deserialization** (#112)
+  - Added proper CompanySearchResult wrapper model for API responses
+  - Company search (`company search --name`) now works correctly
+  - Handles API response format properly
 
 **Installation:**
 Update using the self-update command:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,43 @@
+#### 1.4.0 March 2nd 2026 ####
+
+**Feature and Bug Fix Release**
+
+This release adds company field discovery capabilities and fixes several PowerShell and company search issues.
+
+**New Features:**
+- **Company Fields Command** (#113)
+  - Added `company fields` command for discovering custom fields in your Freshdesk instance
+  - List all available company fields with their types and properties
+  - Essential for building automated company management workflows
+
+**Bug Fixes:**
+- **Fixed PowerShell Completion Installation** (#110, #111)
+  - Removed duplicate 'update' key from PowerShell completion script
+  - Now installs to both PowerShell 5.1 and PowerShell 7 profile paths
+  - Improved compatibility across Windows PowerShell versions
+
+- **Fixed Company Search JSON Deserialization** (#112)
+  - Added proper CompanySearchResult wrapper model for API responses
+  - Company search (`company search --name`) now works correctly
+  - Handles API response format properly
+
+**Installation:**
+Update using the self-update command:
+```bash
+freshdesk update
+```
+
+Or use the one-command installer:
+```bash
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash
+```
+
+**Platform Support:**
+- Linux x64
+- macOS x64 (Intel)
+- macOS ARM64 (Apple Silicon)
+- Windows x64
+
 #### 1.3.1 February 11th 2026 ####
 
 **Bug Fix Release**


### PR DESCRIPTION
## Summary
This PR prepares the 1.4.0 release with bug fixes and new features.

## Changes
- **New Feature:** Added `company fields` command for discovering custom fields
- **Bug Fixes:** 
  - Fixed PowerShell completion installation to both PS5.1 and PS7 profile paths
  - Removed duplicate 'update' key from PowerShell completion script
  - Fixed company search JSON deserialization with CompanySearchResult wrapper

## Release Details
- Version: 1.4.0
- Release Date: March 2nd 2026
- Category: Feature and Bug Fix Release

## Test Plan
- Verify build succeeds with updated version
- Confirm RELEASE_NOTES.md is properly formatted
- Validate version in Directory.Build.props matches 1.4.0