### PR TITLE
fix(attachment-download): strip Basic auth header for S3 pre-signed URLs (#122)

### DIFF
--- a/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
+++ b/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
@@ -16,7 +16,6 @@ public interface IFreshdeskApiClient
     Task<Conversation[]> GetTicketConversationsAsync(long ticketId, CancellationToken cancellationToken = default);
     Task<Conversation> ReplyToTicketAsync(long ticketId, string body, bool isPrivate = false, CancellationToken cancellationToken = default);
     Task<byte[]> DownloadAttachmentAsync(string attachmentUrl, CancellationToken cancellationToken = default);
-    Task<byte[]> DownloadAttachmentByIdAsync(long attachmentId, CancellationToken cancellationToken = default);
     Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default);
 
     Task<Ticket[]> SearchTicketsAsync(string query, int page = 1, CancellationToken cancellationToken = default);
@@ -63,10 +62,11 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
         }
         else
         {
-            var handler = new RateLimitHandler(new HttpClientHandler());
+            var baseAddress = new Uri(_config.ApiV2Url);
+            var handler = new FreshdeskAuthHandler(baseAddress.Host, new RateLimitHandler(new HttpClientHandler()));
             _httpClient = new HttpClient(handler)
             {
-                BaseAddress = new Uri(_config.ApiV2Url)
+                BaseAddress = baseAddress
             };
             _ownsHttpClient = true;
         }
@@ -274,48 +274,12 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
     {
         ArgumentException.ThrowIfNullOrEmpty(attachmentUrl);
 
-        // Check if this is an S3 URL or attachment ID
-        if (attachmentUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
-        {
-            // Try the S3 URL first (it might still be valid)
-            try
-            {
-                var response = await _httpClient.GetAsync(attachmentUrl, cancellationToken);
-                if (response.IsSuccessStatusCode)
-                {
-                    return await response.Content.ReadAsByteArrayAsync(cancellationToken);
-                }
-            }
-            catch { }
+        if (!attachmentUrl.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException($"Invalid attachment URL: {attachmentUrl}", nameof(attachmentUrl));
 
-            // If S3 URL fails, extract attachment ID and use API endpoint
-            var match = System.Text.RegularExpressions.Regex.Match(attachmentUrl, @"/attachments/production/(\d+)/");
-            if (match.Success && long.TryParse(match.Groups[1].Value, out var attachmentId))
-            {
-                return await DownloadAttachmentByIdAsync(attachmentId, cancellationToken);
-            }
-
-            // Last resort: try the URL as-is
-            var finalResponse = await _httpClient.GetAsync(attachmentUrl, cancellationToken);
-            finalResponse.EnsureSuccessStatusCode();
-            return await finalResponse.Content.ReadAsByteArrayAsync(cancellationToken);
-        }
-        else if (long.TryParse(attachmentUrl, out var id))
-        {
-            // It's an attachment ID
-            return await DownloadAttachmentByIdAsync(id, cancellationToken);
-        }
-        else
-        {
-            throw new ArgumentException($"Invalid attachment URL or ID: {attachmentUrl}");
-        }
-    }
-
-    public async Task<byte[]> DownloadAttachmentByIdAsync(long attachmentId, CancellationToken cancellationToken = default)
-    {
-        // Use the direct attachment API endpoint
-        var requestUrl = $"/api/v2/attachments/{attachmentId}";
-        var response = await _httpClient.GetAsync(requestUrl, cancellationToken);
+        // Freshdesk returns pre-signed S3 URLs; FreshdeskAuthHandler strips the Basic auth
+        // header so S3 doesn't reject the mixed authentication with a 400.
+        var response = await _httpClient.GetAsync(attachmentUrl, cancellationToken);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadAsByteArrayAsync(cancellationToken);
     }
@@ -339,20 +303,6 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
         if (_ownsHttpClient)
         {
             _httpClient?.Dispose();
-        }
-    }
-
-    public async Task<byte[]> DownloadAttachmentAsync(string attachmentUrl)
-    {
-        try
-        {
-            var response = await _httpClient.GetAsync(attachmentUrl);
-            response.EnsureSuccessStatusCode();
-            return await response.Content.ReadAsByteArrayAsync();
-        }
-        catch (HttpRequestException ex)
-        {
-            throw new InvalidOperationException($"Failed to download attachment: {ex.Message}", ex);
         }
     }
 

--- a/src/FreshdeskCLI/Services/FreshdeskAuthHandler.cs
+++ b/src/FreshdeskCLI/Services/FreshdeskAuthHandler.cs
@@ -1,0 +1,32 @@
+namespace FreshdeskCLI.Services;
+
+/// <summary>
+/// HTTP delegating handler that strips the Freshdesk Basic auth header from any request
+/// that is not bound for the Freshdesk host. The Freshdesk API hands back pre-signed AWS
+/// S3 URLs for attachments; S3 rejects requests that mix query-string authentication with
+/// an <c>Authorization</c> header, so the inherited default header must be removed before
+/// the attachment download leaves for S3.
+/// </summary>
+public sealed class FreshdeskAuthHandler : DelegatingHandler
+{
+    private readonly string _freshdeskHost;
+
+    public FreshdeskAuthHandler(string freshdeskHost, HttpMessageHandler innerHandler) : base(innerHandler)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(freshdeskHost);
+        _freshdeskHost = freshdeskHost;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.RequestUri is { } uri &&
+            !string.Equals(uri.Host, _freshdeskHost, StringComparison.OrdinalIgnoreCase))
+        {
+            request.Headers.Authorization = null;
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}

--- a/tests/FreshdeskCLI.Tests/Integration/EndToEndTests.cs
+++ b/tests/FreshdeskCLI.Tests/Integration/EndToEndTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using FreshdeskCLI.Models;
@@ -381,6 +382,28 @@ public class EndToEndTests : IDisposable
         Assert.True(File.Exists(filePath));
         var savedContent = await File.ReadAllBytesAsync(filePath);
         Assert.Equal(fileContent, savedContent);
+    }
+
+    [Fact]
+    public async Task DownloadAttachment_SurfacesHttpError()
+    {
+        // Arrange
+        var config = new FreshdeskConfig
+        {
+            Domain = "test",
+            ApiKey = "test-api-key-12345",
+            DefaultDownloadPath = _testDownloadPath
+        };
+
+        var client = new FreshdeskApiClient(config, _httpClient);
+
+        var attachmentUrl = "https://test.freshdesk.com/attachments/789";
+        _mockServer.SetupError("/attachments/789", HttpStatusCode.BadRequest);
+
+        // The 400 must surface as an exception, not be silently swallowed or routed
+        // to a non-existent fallback endpoint.
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.DownloadAttachmentAsync(attachmentUrl));
     }
 
     [Fact]

--- a/tests/FreshdeskCLI.Tests/Services/FreshdeskAuthHandlerTests.cs
+++ b/tests/FreshdeskCLI.Tests/Services/FreshdeskAuthHandlerTests.cs
@@ -1,0 +1,64 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FreshdeskCLI.Services;
+
+namespace FreshdeskCLI.Tests.Services;
+
+public class FreshdeskAuthHandlerTests
+{
+    private const string FreshdeskHost = "test.freshdesk.com";
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+
+    private static async Task<HttpRequestMessage> SendThroughHandlerAsync(string requestUri)
+    {
+        var recorder = new RecordingHandler();
+        var handler = new FreshdeskAuthHandler(FreshdeskHost, recorder);
+        using var invoker = new HttpMessageInvoker(handler);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri)
+        {
+            Headers = { Authorization = new AuthenticationHeaderValue("Basic", "dGVzdC1hcGkta2V5Olg=") }
+        };
+
+        await invoker.SendAsync(request, CancellationToken.None);
+
+        Assert.NotNull(recorder.LastRequest);
+        return recorder.LastRequest!;
+    }
+
+    [Fact]
+    public async Task StripsAuthorization_ForPreSignedS3Url()
+    {
+        var recorded = await SendThroughHandlerAsync(
+            "https://s3.amazonaws.com/euc-freshdesk/data/helpdesk/attachments/production/123/file.csv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc123");
+
+        Assert.Null(recorded.Headers.Authorization);
+    }
+
+    [Fact]
+    public async Task PreservesAuthorization_ForFreshdeskHost()
+    {
+        var recorded = await SendThroughHandlerAsync("https://test.freshdesk.com/api/v2/tickets/1");
+
+        Assert.NotNull(recorded.Headers.Authorization);
+        Assert.Equal("Basic", recorded.Headers.Authorization!.Scheme);
+    }
+
+    [Fact]
+    public async Task PreservesAuthorization_ForFreshdeskHost_RegardlessOfCasing()
+    {
+        var recorded = await SendThroughHandlerAsync("https://TEST.Freshdesk.COM/api/v2/tickets/1");
+
+        Assert.NotNull(recorded.Headers.Authorization);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #122 — `freshdesk attachment download` fails with **HTTP 400 Bad Request** for ticket-level (description) attachments.

**Root cause:** Freshdesk returns pre-signed AWS S3 URLs in `attachment_url` (query-string auth — `X-Amz-Signature`, etc.). The CLI downloads them with the shared `HttpClient`, which carries a default `Authorization: Basic <apikey>` header on *every* request. S3 rejects any request that mixes query-string auth with a header `Authorization` → 400.

Two compounding defects, both confirmed from source:
- The fallback `DownloadAttachmentByIdAsync` called `/api/v2/attachments/{id}` — an endpoint that **does not exist** in the Freshdesk API, so it could never recover.
- A duplicate `DownloadAttachmentAsync(string)` overload shadowed the `CancellationToken` overload, which is why the error message appeared **doubled** (`Failed to download attachment: Failed to download attachment: ...`).

## Changes

- **New `FreshdeskAuthHandler`** — a `DelegatingHandler` that strips the `Authorization` header from any request whose host is not the Freshdesk host. `HttpClient` merges default headers *before* the handler chain runs, so this reliably covers S3/CDN pre-signed URLs while keeping auth for Freshdesk API calls. No constructor signature change.
- **Simplified `DownloadAttachmentAsync`** — removed the silent `catch {}`, the regex/attachment-ID branch, and the broken fallback. HTTP errors now surface instead of being swallowed.
- **Removed** `DownloadAttachmentByIdAsync` (incl. interface declaration) and the duplicate `DownloadAttachmentAsync(string)` overload.

## Testing

- New `FreshdeskAuthHandlerTests` — verifies auth is stripped for pre-signed S3 URLs and preserved for the Freshdesk host (incl. case-insensitive host match).
- New `DownloadAttachment_SurfacesHttpError` — a 400 now surfaces as an exception rather than being swallowed / routed to the non-existent fallback endpoint.
- All 123 tests pass; AOT publish builds clean (9.7 MB binary, no trim/AOT warnings).

A live S3 round-trip can't run in CI (no test Freshdesk instance) — the auth-stripping logic is unit-tested directly. Worth a manual check against a real ticket with a description-level attachment before release.

> Note: issue #123 (Freshdesk's server-side HTML sanitizer) is intentionally **not** addressed here — it stays open as a separate follow-up.