### PR TITLE
Preserve paragraph spacing in markdown replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ freshdesk ticket search --email john@example.com --format csv
 
 #### Reply to Tickets
 
-Reply content is read from a file (`--file` is required), treated as Markdown, and converted to HTML before being sent to Freshdesk. Raw HTML in the file is escaped rather than passed through.
+Reply content is read from a file (`--file` is required), treated as Markdown, and converted to HTML before being sent to Freshdesk. Raw HTML in the file is escaped rather than passed through. Freshdesk HTML rewriting is handled with paragraph-safe output so blank lines and basic spacing are preserved.
 
 ```bash
 # Reply from a Markdown file
@@ -245,7 +245,7 @@ freshdesk ticket reply 123 -f response.txt
 
 #### Add Internal Notes
 
-Note content is read from a file (`--file` is required) and converted from Markdown to HTML, same as replies.
+Note content is read from a file (`--file` is required) and converted from Markdown to HTML, same as replies, with paragraph spacing preserved.
 
 ```bash
 # Add note from a Markdown file

--- a/src/FreshdeskCLI/Helpers/CommandHelp.cs
+++ b/src/FreshdeskCLI/Helpers/CommandHelp.cs
@@ -156,7 +156,7 @@ public static class CommandHelp
         ["ticket reply"] = new CommandHelpInfo
         {
             Usage = "freshdesk ticket reply <ticket-id> --file <path>",
-            Description = "Reply to a ticket. The file content is treated as Markdown and converted to HTML.",
+            Description = "Reply to a ticket. The file content is treated as Markdown and converted to HTML with preserved paragraph spacing.",
             Options = new Dictionary<string, string>
             {
                 ["--file, -f <path>"] = "Read reply message from file (required)",
@@ -171,7 +171,7 @@ public static class CommandHelp
         ["ticket note"] = new CommandHelpInfo
         {
             Usage = "freshdesk ticket note <ticket-id> --file <path>",
-            Description = "Add an internal note to a ticket. The file content is treated as Markdown and converted to HTML.",
+            Description = "Add an internal note to a ticket. The file content is treated as Markdown and converted to HTML with preserved paragraph spacing.",
             Options = new Dictionary<string, string>
             {
                 ["--file, -f <path>"] = "Read note message from file (required)",

--- a/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
+++ b/src/FreshdeskCLI/Services/FreshdeskApiClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Markdig;
 using FreshdeskCLI.Models;
 
@@ -298,6 +299,18 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
                 .DisableHtml()
                 .Build());
 
+    private static readonly Regex ParagraphRegex = new(
+        @"<p>(.*?)</p>",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
+
+    private static readonly Regex ListItemOpenTagRegex = new(
+        @"<li\b[^>]*>",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private static readonly Regex ListItemCloseTagRegex = new(
+        @"</li\s*>",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
     private static MarkdownPipeline MarkdownPipeline => _markdownPipelineLazy.Value;
 
     /// <summary>
@@ -306,7 +319,31 @@ public sealed class FreshdeskApiClient : IFreshdeskApiClient, IDisposable
     /// </summary>
     internal static string ConvertMarkdownToHtml(string markdown)
     {
-        return Markdown.ToHtml(markdown, MarkdownPipeline);
+        return MakeParagraphsFreshdeskSafe(Markdown.ToHtml(markdown, MarkdownPipeline));
+    }
+
+    private static string MakeParagraphsFreshdeskSafe(string html)
+    {
+        if (string.IsNullOrEmpty(html))
+        {
+            return html;
+        }
+
+        return ParagraphRegex.Replace(html, match =>
+        {
+            var content = match.Groups[1].Value;
+            var isInListItem = IsInsideListItem(html, match.Index);
+            var spacing = isInListItem ? "<br>" : "<br><br>";
+            return $"<div>{content}{spacing}</div>";
+        });
+    }
+
+    private static bool IsInsideListItem(string html, int paragraphStartIndex)
+    {
+        var beforeParagraph = html[..paragraphStartIndex];
+        var openListItemCount = ListItemOpenTagRegex.Matches(beforeParagraph).Count;
+        var closeListItemCount = ListItemCloseTagRegex.Matches(beforeParagraph).Count;
+        return openListItemCount > closeListItemCount;
     }
 
     public async Task<bool> TestConnectionAsync(CancellationToken cancellationToken = default)

--- a/tests/FreshdeskCLI.Tests/Services/MarkdownConversionTests.cs
+++ b/tests/FreshdeskCLI.Tests/Services/MarkdownConversionTests.cs
@@ -18,8 +18,19 @@ public class MarkdownConversionTests
         var html = FreshdeskApiClient.ConvertMarkdownToHtml("- first\n- second");
 
         Assert.Contains("<ul>", html);
-        Assert.Contains("<li>first</li>", html);
-        Assert.Contains("<li>second</li>", html);
+        Assert.Contains("<li>first", html);
+        Assert.Contains("<li>second", html);
+    }
+
+    [Fact]
+    public void ConvertsParagraphsToFreshdeskSafeDivs()
+    {
+        var html = FreshdeskApiClient.ConvertMarkdownToHtml("First paragraph.\n\nSecond paragraph.");
+
+        Assert.Contains("<div>First paragraph.<br><br></div>", html);
+        Assert.Contains("<div>Second paragraph.<br><br></div>", html);
+        Assert.DoesNotContain("<p>", html);
+        Assert.DoesNotContain("</p>", html);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes issue with ticket reply/note file content collapsing paragraph spacing when Freshdesk rewrites HTML.
