### PR TITLE
Remove --message/-m flag from reply and note commands

### DIFF
--- a/src/FreshdeskCLI/Helpers/CommandHelp.cs
+++ b/src/FreshdeskCLI/Helpers/CommandHelp.cs
@@ -159,8 +159,7 @@ public static class CommandHelp
             Description = "Reply to a ticket. The file content is treated as Markdown and converted to HTML with preserved paragraph spacing.",
             Options = new Dictionary<string, string>
             {
-                ["--file, -f <path>"] = "Read reply message from file (required)",
-                ["--message, -m <text>"] = "[Deprecated] Inline reply message; use --file instead"
+                ["--file, -f <path>"] = "Read reply message from file (required)"
             },
             Examples = new[]
             {
@@ -174,8 +173,7 @@ public static class CommandHelp
             Description = "Add an internal note to a ticket. The file content is treated as Markdown and converted to HTML with preserved paragraph spacing.",
             Options = new Dictionary<string, string>
             {
-                ["--file, -f <path>"] = "Read note message from file (required)",
-                ["--message, -m <text>"] = "[Deprecated] Inline note message; use --file instead"
+                ["--file, -f <path>"] = "Read note message from file (required)"
             },
             Examples = new[]
             {

--- a/src/FreshdeskCLI/Program.cs
+++ b/src/FreshdeskCLI/Program.cs
@@ -894,48 +894,53 @@ static async Task<int> HandleTicketReply(string[] args, FreshdeskCLI.Services.Fr
         return 1;
     }
 
-    string? filePath = null;
-    string? message = null;
-
-    for (int i = 1; i < args.Length; i++)
+    // Scan for --message/-m usage and redirect users
+    foreach (var arg in args)
     {
-        switch (args[i])
+        if (arg == "--message" || arg == "-m")
         {
-            case "--message":
-            case "-m":
-                if (i + 1 < args.Length)
-                {
-                    message = args[++i];
-                    Console.Error.WriteLine("Warning: --message is deprecated. Use --file instead. This will be removed in a future version.");
-                }
-                break;
-            case "--file":
-            case "-f":
-                if (i + 1 < args.Length)
-                    filePath = args[++i];
-                break;
+            Console.Error.WriteLine("");
+            Console.Error.WriteLine("⚠️  --message/-m has been removed.");
+            Console.Error.WriteLine("   Write your reply to a file and use --file instead.");
+            Console.Error.WriteLine("   Usage: freshdesk ticket reply <id> --file reply.md");
+            Console.Error.WriteLine("");
+            return 1;
         }
     }
 
-    if (string.IsNullOrEmpty(filePath) && string.IsNullOrEmpty(message))
+    if (args.Length < 3)
     {
         Console.WriteLine("Error: --file is required for replies.");
         Console.WriteLine("Run 'freshdesk ticket reply --help' for usage information.");
         return 1;
     }
 
-    if (!string.IsNullOrEmpty(filePath))
+    // Find --file flag
+    string? filePath = null;
+    for (int i = 1; i < args.Length; i++)
     {
-        if (!File.Exists(filePath))
+        if ((args[i] == "--file" || args[i] == "-f") && i + 1 < args.Length)
         {
-            Console.WriteLine($"File not found: {filePath}");
-            return 1;
+            filePath = args[++i];
+            break;
         }
-
-        message = await File.ReadAllTextAsync(filePath);
     }
 
-    message = NormalizeLineEndings(message!);
+    if (string.IsNullOrEmpty(filePath))
+    {
+        Console.WriteLine("Error: --file is required for replies.");
+        Console.WriteLine("Run 'freshdesk ticket reply --help' for usage information.");
+        return 1;
+    }
+
+    if (!File.Exists(filePath))
+    {
+        Console.WriteLine($"File not found: {filePath}");
+        return 1;
+    }
+
+    string message = await File.ReadAllTextAsync(filePath);
+    message = NormalizeLineEndings(message);
 
     if (string.IsNullOrEmpty(message))
     {
@@ -973,50 +978,48 @@ static async Task<int> HandleTicketNote(string[] args, FreshdeskCLI.Services.Fre
         return 1;
     }
 
-    string? filePath = null;
-    string? message = null;
-
-    for (int i = 1; i < args.Length; i++)
+    // Scan for --message/-m usage and redirect users
+    foreach (var arg in args)
     {
-        switch (args[i])
+        if (arg == "--message" || arg == "-m")
         {
-            case "--message":
-            case "-m":
-                if (i + 1 < args.Length)
-                {
-                    message = args[++i];
-                    Console.Error.WriteLine("Warning: --message is deprecated. Use --file instead. This will be removed in a future version.");
-                }
-                break;
-            case "--file":
-            case "-f":
-                if (i + 1 < args.Length)
-                    filePath = args[++i];
-                break;
+            Console.Error.WriteLine("");
+            Console.Error.WriteLine("⚠️  --message/-m has been removed.");
+            Console.Error.WriteLine("   Write your note to a file and use --file instead.");
+            Console.Error.WriteLine("   Usage: freshdesk ticket note <id> --file note.md");
+            Console.Error.WriteLine("");
+            return 1;
         }
     }
 
-    if (string.IsNullOrEmpty(filePath) && string.IsNullOrEmpty(message))
+    string? filePath = null;
+
+    for (int i = 1; i < args.Length; i++)
+    {
+        if ((args[i] == "--file" || args[i] == "-f") && i + 1 < args.Length)
+        {
+            filePath = args[++i];
+            break;
+        }
+    }
+
+    if (string.IsNullOrEmpty(filePath))
     {
         Console.WriteLine("Error: --file is required for notes.");
         Console.WriteLine("Run 'freshdesk ticket note --help' for usage information.");
         return 1;
     }
 
-    if (!string.IsNullOrEmpty(filePath))
+    if (!File.Exists(filePath))
     {
-        if (!File.Exists(filePath))
-        {
-            Console.WriteLine($"File not found: {filePath}");
-            return 1;
-        }
-
-        message = await File.ReadAllTextAsync(filePath);
+        Console.WriteLine($"File not found: {filePath}");
+        return 1;
     }
 
-    message = NormalizeLineEndings(message!);
+    string noteText = await File.ReadAllTextAsync(filePath);
+    noteText = NormalizeLineEndings(noteText);
 
-    if (string.IsNullOrEmpty(message))
+    if (string.IsNullOrEmpty(noteText))
     {
         Console.WriteLine("No message provided (file is empty).");
         return 1;
@@ -1025,7 +1028,7 @@ static async Task<int> HandleTicketNote(string[] args, FreshdeskCLI.Services.Fre
     try
     {
         Console.WriteLine($"Adding internal note to ticket #{ticketId}...");
-        var conversation = await client.ReplyToTicketAsync(ticketId, message, isPrivate: true);
+        var conversation = await client.ReplyToTicketAsync(ticketId, noteText, isPrivate: true);
         Console.WriteLine($"✓ Internal note added successfully!");
         Console.WriteLine($"  Note ID: {conversation.Id}");
         Console.WriteLine($"  Created: {conversation.CreatedAt:yyyy-MM-dd HH:mm:ss}");


### PR DESCRIPTION
## Summary

Removes the `--message` / `-m` flags from both `ticket reply` and `ticket note` commands. File-based input via `--file` is now the only supported method.

## Breaking Change

**Before:** `freshdesk ticket reply 609 --message "Hello world"`

**After:** This shows a helpful error redirecting the user to `--file`:

```
⚠️  --message/-m has been removed.
   Write your reply to a file and use --file instead.
   Usage: freshdesk ticket reply <id> --file reply.md
```

## Rationale

The `--message` flag caused formatting issues that were impossible to reliably fix. By making file-based input the only path, we ensure consistent, correctly-formatted replies.

## Files Changed

- `src/FreshdeskCLI/Program.cs` — Removed `--message` parsing from `HandleTicketReply` and `HandleTicketNote`, replaced with redirect error
- `src/FreshdeskCLI/Helpers/CommandHelp.cs` — Removed `--message` from help text options
