### PR TITLE
Prepare release 1.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,22 +1,35 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <!-- Version configuration -->
-    <VersionPrefix>1.5.1</VersionPrefix>
+    <VersionPrefix>1.6.0</VersionPrefix>
     <!-- Get Git commit hash at build time -->
     <SourceRevisionId Condition="'$(SourceRevisionId)' == ''">$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</SourceRevisionId>
-    <PackageReleaseNotes>**Bug Fix Release**
+    <PackageReleaseNotes>**Breaking Change Release**
 
-This release fixes paragraph spacing in markdown-formatted ticket replies and notes so text no longer collapses after Freshdesk renders HTML.
+This release removes the `--message` / `-m` flags from both `ticket reply` and `ticket note` commands. File-based input via `--file` is now the only supported method.
 
-**Bug Fixes:**
-- **Preserve Paragraph Spacing in Markdown Replies and Notes** ([#136](https://github.com/Aaronontheweb/freshdesk-cli/pull/136))
-  - `ticket reply` and `ticket note` now keep paragraph breaks after Markdown-to-HTML conversion, preventing collapsed text in Freshdesk.
-  - Markdown content is rewritten into paragraph-safe HTML blocks so single and multi-paragraph messages retain readable spacing.
-  - Updated help text and tests to document and verify the improved spacing behavior.
+**Breaking Changes:**
+- **Removed `--message` / `-m` flag from `ticket reply`** ([#140](https://github.com/Aaronontheweb/freshdesk-cli/pull/140))
+  - Inline message replies are no longer supported
+  - Using `--message` or `-m` now shows a clear error redirecting users to `--file`
+  - This was a breaking change driven by persistent formatting issues that made inline messages unreliable
+- **Removed `--message` / `-m` flag from `ticket note`** ([#140](https://github.com/Aaronontheweb/freshdesk-cli/pull/140))
+  - Same removal for internal notes
+
+**Migration:**
+Instead of:
+```bash
+freshdesk ticket reply 609 --message "Hello world"
+```
+
+Write your reply to a file and use:
+```bash
+freshdesk ticket reply 609 --file reply.md
+```
 
 **Technical Improvements:**
-- Added spacing-safe conversion logic in markdown rendering to avoid paragraph collapse in list-heavy and standard markdown content.
+- Cleaner command parsing logic (removed deprecated flag handling code)
 
 **Installation:**
 Update using the self-update command:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,48 @@
+#### 1.6.0 June 18th 2026 ####
+
+**Breaking Change Release**
+
+This release removes the `--message` / `-m` flags from both `ticket reply` and `ticket note` commands. File-based input via `--file` is now the only supported method.
+
+**Breaking Changes:**
+- **Removed `--message` / `-m` flag from `ticket reply`** ([#140](https://github.com/Aaronontheweb/freshdesk-cli/pull/140))
+  - Inline message replies are no longer supported
+  - Using `--message` or `-m` now shows a clear error redirecting users to `--file`
+  - This was a breaking change driven by persistent formatting issues that made inline messages unreliable
+- **Removed `--message` / `-m` flag from `ticket note`** ([#140](https://github.com/Aaronontheweb/freshdesk-cli/pull/140))
+  - Same removal for internal notes
+
+**Migration:**
+Instead of:
+```bash
+freshdesk ticket reply 609 --message "Hello world"
+```
+
+Write your reply to a file and use:
+```bash
+freshdesk ticket reply 609 --file reply.md
+```
+
+**Technical Improvements:**
+- Cleaner command parsing logic (removed deprecated flag handling code)
+
+**Installation:**
+Update using the self-update command:
+```bash
+freshdesk update
+```
+
+Or use the one-command installer:
+```bash
+curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash
+```
+
+**Platform Support:**
+- Linux x64
+- macOS x64 (Intel)
+- macOS ARM64 (Apple Silicon)
+- Windows x64
+
 #### 1.5.1 2026-06-10 ####
 
 **Bug Fix Release**


### PR DESCRIPTION
## Release 1.6.0

**Breaking Change Release**

This release removes the `--message` / `-m` flags from both `ticket reply` and `ticket note` commands. File-based input via `--file` is now the only supported method.

### Breaking Changes

- **Removed `--message` / `-m` flag from `ticket reply`** (#140)
  - Inline message replies are no longer supported
  - Using `--message` or `-m` now shows a clear error redirecting users to `--file`
  - This was a breaking change driven by persistent formatting issues that made inline messages unreliable
- **Removed `--message` / `-m` flag from `ticket note`** (#140)
  - Same removal for internal notes

### Migration

Instead of:
```bash
freshdesk ticket reply 609 --message "Hello world"
```

Write your reply to a file and use:
```bash
freshdesk ticket reply 609 --file reply.md
```

### Technical Improvements

- Cleaner command parsing logic (removed deprecated flag handling code)

### Install

```bash
freshdesk update
```

Or:
```bash
curl -sSL https://raw.githubusercontent.com/Aaronontheweb/freshdesk-cli/dev/install.sh | bash
```